### PR TITLE
fix: Spotless formatter를 Palantir Java Format으로 변경

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <logback-classic-db.version>1.2.11.1</logback-classic-db.version>
         <!-- Code Quality Plugins -->
         <spotless.version>2.44.0</spotless.version>
-        <google-java-format.version>1.25.2</google-java-format.version>
+        <palantir-java-format.version>2.50.0</palantir-java-format.version>
         <sonar.organization>neobnsrnd-team</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.projectKey>neobnsrnd-team_spider-admin-v2</sonar.projectKey>
@@ -189,10 +189,9 @@
                 <version>${spotless.version}</version>
                 <configuration>
                     <java>
-                        <googleJavaFormat>
-                            <version>${google-java-format.version}</version>
-                            <style>AOSP</style>
-                        </googleJavaFormat>
+                        <palantirJavaFormat>
+                            <version>${palantir-java-format.version}</version>
+                        </palantirJavaFormat>
                         <importOrder>
                             <order>java|javax,org,com,,\#</order>
                         </importOrder>

--- a/src/test/java/org/example/springadminv2/architecture/ArchitectureTest.java
+++ b/src/test/java/org/example/springadminv2/architecture/ArchitectureTest.java
@@ -12,8 +12,7 @@ import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 
 class ArchitectureTest {
 
-    private static final JavaClasses classes =
-            new ClassFileImporter().importPackages("org.example.springadminv2");
+    private static final JavaClasses classes = new ClassFileImporter().importPackages("org.example.springadminv2");
 
     // ── 레이어 의존성: Controller → Service → Mapper 단방향만 허용 ──
 


### PR DESCRIPTION
## Summary

- Closes #28 
- Spotless 코드 포맷터를 Google Java Format(AOSP)에서 **Palantir Java Format v2.50.0**으로 변경
- 개발 표준 문서(Code Convention.md)에 명시된 설정과 실제 pom.xml 설정의 불일치를 해소
- 기존 소스 코드에 Palantir 포맷 적용 (`spotless:apply`)

## Changes
| 항목 | Before | After |
|------|--------|-------|
| Formatter | Google Java Format 1.25.2 (AOSP) | Palantir Java Format 2.50.0 |
| Style | AOSP (4-space indent) | Palantir (4-space indent, 120 char line) |

## Test plan
- [x] `mvn spotless:apply` 성공
- [x] `mvn clean verify` 빌드 성공 (테스트 7개 통과)
- [ ] CI pipeline 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)