### PR TITLE
feat#31: Node.js 빌드 통합 (ESLint + Tailwind CSS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ build/
 ### Environment ###
 .env
 
+### Frontend Build ###
+src/main/frontend/node/
+src/main/frontend/node_modules/
+
 ### Claude ###
 .claude/
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
         <springdoc.version>2.3.0</springdoc.version>
         <logstash-logback.version>8.0</logstash-logback.version>
         <logback-classic-db.version>1.2.11.1</logback-classic-db.version>
+        <!-- Frontend Build -->
+        <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
+        <node.version>v20.11.0</node.version>
         <!-- Code Quality Plugins -->
         <spotless.version>2.44.0</spotless.version>
         <palantir-java-format.version>2.50.0</palantir-java-format.version>
@@ -208,6 +211,34 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+
+            <!-- ── Frontend (Node.js + npm) ── -->
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend-maven-plugin.version}</version>
+                <configuration>
+                    <nodeVersion>${node.version}</nodeVersion>
+                    <workingDirectory>src/main/frontend</workingDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-node-and-npm</id>
+                        <goals><goal>install-node-and-npm</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>npm-install</id>
+                        <goals><goal>npm</goal></goals>
+                        <configuration><arguments>install</arguments></configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-build</id>
+                        <goals><goal>npm</goal></goals>
+                        <phase>generate-resources</phase>
+                        <configuration><arguments>run build</arguments></configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- ── Surefire (Test Execution) ── -->

--- a/src/main/frontend/eslint.config.js
+++ b/src/main/frontend/eslint.config.js
@@ -1,0 +1,22 @@
+import globals from 'globals';
+
+export default [{
+  files: ['../resources/static/js/**/*.js'],
+  languageOptions: {
+    globals: {
+      ...globals.browser,
+      ...globals.jquery,
+    },
+  },
+  rules: {
+    'no-var':                'error',
+    'no-implicit-globals':   'error',
+    'eqeqeq':               'error',
+    'prefer-const':          'warn',
+    'no-restricted-globals': ['error', { name: 'fetch', message: 'Use $.ajax() instead.' }],
+    'no-restricted-syntax':  ['warn',
+      { selector: "CallExpression[callee.property.name='addEventListener']",
+        message: 'Use jQuery .off().on() instead.' }
+    ],
+  },
+}];

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "spider-admin-v2-frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "npm run lint && npm run css:build",
+    "css:build": "postcss src/input.css -o ../resources/static/css/app.css",
+    "css:watch": "postcss src/input.css -o ../resources/static/css/app.css --watch",
+    "lint": "eslint --no-error-on-unmatched-pattern ../resources/static/js/"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.17",
+    "postcss": "^8.4.49",
+    "postcss-cli": "^11.0.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.17.0",
+    "globals": "^15.14.0"
+  }
+}

--- a/src/main/frontend/postcss.config.js
+++ b/src/main/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/main/frontend/src/input.css
+++ b/src/main/frontend/src/input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main/frontend/tailwind.config.js
+++ b/src/main/frontend/tailwind.config.js
@@ -1,0 +1,26 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    '../resources/templates/**/*.html',
+    '../resources/static/js/**/*.js',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary:     { DEFAULT: '#0f62fe', hover: '#0353e9' },
+        secondary:   { DEFAULT: '#393939', hover: '#4c4c4c' },
+        destructive: { DEFAULT: '#da1e28', hover: '#ba1b23' },
+        success:     { DEFAULT: '#24a148', hover: '#198038' },
+        warning:     { DEFAULT: '#f1c21b', hover: '#d2a106' },
+        surface:     { DEFAULT: '#ffffff', secondary: '#f4f4f4' },
+      },
+      spacing: {
+        compact:   '0.5rem',
+        regular:   '1rem',
+        generous:  '1.5rem',
+        spacious:  '2rem',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- `frontend-maven-plugin`으로 Node.js 20.x 자동 설치 및 `npm run build`를 Maven `generate-resources` 단계에 통합
- ESLint 9.x 설정 (`no-var`, `eqeqeq`, `no-restricted-globals(fetch)` 등 Frontend Code Convention 준수)
- Tailwind CSS 3.4.x + PostCSS 빌드 파이프라인 구성 (Design System 색상/간격 토큰 포함)

## Test plan
- [x] `mvn generate-resources` — Node.js 설치 → npm install → lint + css:build 성공
- [x] `src/main/resources/static/css/app.css` 파일 생성 확인
- [x] `mvn verify -B -Dtest.excludedGroups=docker` — 전체 빌드 통과 (38 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)