### PR TITLE
feat#36: Multi-DB 지원 구성 (DatabaseIdProvider, HikariCP)

### DIFF
--- a/src/main/java/org/example/springadminv2/global/config/MyBatisConfig.java
+++ b/src/main/java/org/example/springadminv2/global/config/MyBatisConfig.java
@@ -1,0 +1,23 @@
+package org.example.springadminv2.global.config;
+
+import java.util.Properties;
+
+import org.apache.ibatis.mapping.DatabaseIdProvider;
+import org.apache.ibatis.mapping.VendorDatabaseIdProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MyBatisConfig {
+
+    @Bean
+    public DatabaseIdProvider databaseIdProvider() {
+        VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
+        Properties properties = new Properties();
+        properties.setProperty("Oracle", "oracle");
+        properties.setProperty("MySQL", "mysql");
+        properties.setProperty("PostgreSQL", "postgresql");
+        provider.setProperties(properties);
+        return provider;
+    }
+}

--- a/src/main/resources/application-mysql.yml
+++ b/src/main/resources/application-mysql.yml
@@ -4,6 +4,13 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      pool-name: mysql-pool
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
 pagehelper:
   helper-dialect: mysql

--- a/src/main/resources/application-oracle.yml
+++ b/src/main/resources/application-oracle.yml
@@ -5,6 +5,12 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: oracle.jdbc.OracleDriver
     hikari:
+      pool-name: oracle-pool
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
       connection-init-sql: ALTER SESSION SET CURRENT_SCHEMA = ${DB_SCHEMA}
 
 pagehelper:

--- a/src/test/java/org/example/springadminv2/config/MyBatisConfigTest.java
+++ b/src/test/java/org/example/springadminv2/config/MyBatisConfigTest.java
@@ -1,0 +1,21 @@
+package org.example.springadminv2.config;
+
+import org.apache.ibatis.mapping.DatabaseIdProvider;
+import org.example.springadminv2.global.config.MyBatisConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MyBatisConfigTest {
+
+    private final MyBatisConfig config = new MyBatisConfig();
+
+    @Test
+    @DisplayName("DatabaseIdProvider Bean이 정상 생성된다")
+    void databaseIdProvider_isNotNull() {
+        DatabaseIdProvider provider = config.databaseIdProvider();
+
+        assertThat(provider).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- MyBatisConfig에 `DatabaseIdProvider` Bean 등록 (Oracle/MySQL/PostgreSQL 벤더 매핑)
- `application-oracle.yml`, `application-mysql.yml`에 HikariCP 풀 설정 추가 (pool-name, pool-size, timeout)
- `MyBatisConfigTest` 추가

## Test plan
- [x] MyBatisConfigTest — DatabaseIdProvider Bean 생성 검증
- [x] 전체 테스트 73건 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)