### PR TITLE
feat#43: Menu-Resource 권한 통합 (YAML 기반 리소스 파생)

### DIFF
--- a/src/main/java/org/example/springadminv2/global/security/config/MenuResourcePermissions.java
+++ b/src/main/java/org/example/springadminv2/global/security/config/MenuResourcePermissions.java
@@ -1,0 +1,99 @@
+package org.example.springadminv2.global.security.config;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.example.springadminv2.global.security.constant.MenuAccessLevel;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class MenuResourcePermissions {
+
+    private static final String YAML_PATH = "menu-resource-permissions.yml";
+    private static final String READ_SUFFIX = "_READ";
+    private static final String WRITE_SUFFIX = "_WRITE";
+    private static final Set<String> SPECIAL_VALUES = Set.of("permitAll", "isAuthenticated");
+
+    private final Map<String, List<String>> readResources = new HashMap<>();
+    private final Map<String, List<String>> writeResources = new HashMap<>();
+
+    @PostConstruct
+    void init() {
+        Yaml yaml = new Yaml();
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(YAML_PATH)) {
+            if (is == null) {
+                throw new IllegalStateException("Resource not found: " + YAML_PATH);
+            }
+            Map<String, String> entries = yaml.load(is);
+            if (entries == null) {
+                return;
+            }
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+
+                if (SPECIAL_VALUES.contains(value)) {
+                    continue;
+                }
+
+                if (key.endsWith(READ_SUFFIX)) {
+                    String menuId = key.substring(0, key.length() - READ_SUFFIX.length());
+                    readResources.put(menuId, parseResources(value));
+                } else if (key.endsWith(WRITE_SUFFIX)) {
+                    String menuId = key.substring(0, key.length() - WRITE_SUFFIX.length());
+                    writeResources.put(menuId, parseResources(value));
+                }
+            }
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("Failed to load " + YAML_PATH, e);
+        }
+    }
+
+    public Set<String> getDerivedResourceAuthorities(String menuId, MenuAccessLevel level) {
+        Set<String> authorities = new HashSet<>();
+
+        List<String> reads = readResources.getOrDefault(menuId, Collections.emptyList());
+        authorities.addAll(reads);
+
+        if (level == MenuAccessLevel.WRITE) {
+            List<String> writes = writeResources.getOrDefault(menuId, Collections.emptyList());
+            authorities.addAll(writes);
+        }
+
+        return authorities;
+    }
+
+    private List<String> parseResources(String value) {
+        List<String> resources = new ArrayList<>();
+        for (String token : value.split(",")) {
+            String trimmed = token.trim();
+            if (!trimmed.isEmpty()) {
+                resources.add(toAuthorityFormat(trimmed));
+            }
+        }
+        return resources;
+    }
+
+    private String toAuthorityFormat(String yamlResource) {
+        if (yamlResource.endsWith(READ_SUFFIX)) {
+            return yamlResource.substring(0, yamlResource.length() - READ_SUFFIX.length())
+                    + ":"
+                    + MenuAccessLevel.READ.getCode();
+        }
+        if (yamlResource.endsWith(WRITE_SUFFIX)) {
+            return yamlResource.substring(0, yamlResource.length() - WRITE_SUFFIX.length())
+                    + ":"
+                    + MenuAccessLevel.WRITE.getCode();
+        }
+        return yamlResource;
+    }
+}

--- a/src/main/java/org/example/springadminv2/global/security/converter/AuthorityConverter.java
+++ b/src/main/java/org/example/springadminv2/global/security/converter/AuthorityConverter.java
@@ -1,0 +1,42 @@
+package org.example.springadminv2.global.security.converter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.example.springadminv2.global.security.config.MenuResourcePermissions;
+import org.example.springadminv2.global.security.constant.MenuAccessLevel;
+import org.example.springadminv2.global.security.dto.MenuPermission;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorityConverter {
+
+    private final MenuResourcePermissions menuResourcePermissions;
+
+    public Set<GrantedAuthority> convert(List<MenuPermission> permissions) {
+        Set<GrantedAuthority> authorities = new HashSet<>();
+
+        for (MenuPermission permission : permissions) {
+            MenuAccessLevel level = MenuAccessLevel.fromCode(permission.authCode());
+            String menuId = permission.menuId();
+
+            authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.READ.getCode()));
+            if (level == MenuAccessLevel.WRITE) {
+                authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.WRITE.getCode()));
+            }
+
+            Set<String> derivedResources = menuResourcePermissions.getDerivedResourceAuthorities(menuId, level);
+            for (String resource : derivedResources) {
+                authorities.add(new SimpleGrantedAuthority(resource));
+            }
+        }
+
+        return authorities;
+    }
+}

--- a/src/main/java/org/example/springadminv2/global/security/provider/RoleMenuAuthorityProvider.java
+++ b/src/main/java/org/example/springadminv2/global/security/provider/RoleMenuAuthorityProvider.java
@@ -1,15 +1,13 @@
 package org.example.springadminv2.global.security.provider;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.example.springadminv2.global.security.constant.MenuAccessLevel;
+import org.example.springadminv2.global.security.converter.AuthorityConverter;
 import org.example.springadminv2.global.security.dto.MenuPermission;
 import org.example.springadminv2.global.security.mapper.AuthorityMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -20,23 +18,11 @@ import lombok.RequiredArgsConstructor;
 public class RoleMenuAuthorityProvider implements AuthorityProvider {
 
     private final AuthorityMapper authorityMapper;
+    private final AuthorityConverter authorityConverter;
 
     @Override
     public Set<GrantedAuthority> getAuthorities(String userId, String roleId) {
         List<MenuPermission> permissions = authorityMapper.selectMenuPermissionsByRoleId(roleId);
-        return toGrantedAuthorities(permissions);
-    }
-
-    private Set<GrantedAuthority> toGrantedAuthorities(List<MenuPermission> permissions) {
-        Set<GrantedAuthority> authorities = new HashSet<>();
-        for (MenuPermission permission : permissions) {
-            MenuAccessLevel level = MenuAccessLevel.fromCode(permission.authCode());
-            String menuId = permission.menuId();
-            authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.READ.getCode()));
-            if (level == MenuAccessLevel.WRITE) {
-                authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.WRITE.getCode()));
-            }
-        }
-        return authorities;
+        return authorityConverter.convert(permissions);
     }
 }

--- a/src/main/java/org/example/springadminv2/global/security/provider/UserMenuAuthorityProvider.java
+++ b/src/main/java/org/example/springadminv2/global/security/provider/UserMenuAuthorityProvider.java
@@ -1,15 +1,13 @@
 package org.example.springadminv2.global.security.provider;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.example.springadminv2.global.security.constant.MenuAccessLevel;
+import org.example.springadminv2.global.security.converter.AuthorityConverter;
 import org.example.springadminv2.global.security.dto.MenuPermission;
 import org.example.springadminv2.global.security.mapper.AuthorityMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -20,23 +18,11 @@ import lombok.RequiredArgsConstructor;
 public class UserMenuAuthorityProvider implements AuthorityProvider {
 
     private final AuthorityMapper authorityMapper;
+    private final AuthorityConverter authorityConverter;
 
     @Override
     public Set<GrantedAuthority> getAuthorities(String userId, String roleId) {
         List<MenuPermission> permissions = authorityMapper.selectMenuPermissionsByUserId(userId);
-        return toGrantedAuthorities(permissions);
-    }
-
-    private Set<GrantedAuthority> toGrantedAuthorities(List<MenuPermission> permissions) {
-        Set<GrantedAuthority> authorities = new HashSet<>();
-        for (MenuPermission permission : permissions) {
-            MenuAccessLevel level = MenuAccessLevel.fromCode(permission.authCode());
-            String menuId = permission.menuId();
-            authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.READ.getCode()));
-            if (level == MenuAccessLevel.WRITE) {
-                authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.WRITE.getCode()));
-            }
-        }
-        return authorities;
+        return authorityConverter.convert(permissions);
     }
 }

--- a/src/test/java/org/example/springadminv2/security/AuthorityConverterTest.java
+++ b/src/test/java/org/example/springadminv2/security/AuthorityConverterTest.java
@@ -1,0 +1,121 @@
+package org.example.springadminv2.security;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.example.springadminv2.global.security.config.MenuResourcePermissions;
+import org.example.springadminv2.global.security.constant.MenuAccessLevel;
+import org.example.springadminv2.global.security.converter.AuthorityConverter;
+import org.example.springadminv2.global.security.dto.MenuPermission;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorityConverterTest {
+
+    @Mock
+    MenuResourcePermissions menuResourcePermissions;
+
+    @InjectMocks
+    AuthorityConverter converter;
+
+    @Test
+    @DisplayName("READ 권한 변환 시 메뉴 READ + 파생 리소스를 반환한다")
+    void convert_read_returns_menu_read_and_derived_resources() {
+        // given
+        List<MenuPermission> permissions = List.of(new MenuPermission("v3_menu_manage", "R"));
+        given(menuResourcePermissions.getDerivedResourceAuthorities("v3_menu_manage", MenuAccessLevel.READ))
+                .willReturn(Set.of("RES_MENU:R"));
+
+        // when
+        Set<GrantedAuthority> result = converter.convert(permissions);
+
+        // then
+        assertThat(result)
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("v3_menu_manage:R", "RES_MENU:R");
+    }
+
+    @Test
+    @DisplayName("WRITE 권한 변환 시 메뉴 READ+WRITE + 파생 리소스를 반환한다")
+    void convert_write_returns_menu_read_write_and_derived_resources() {
+        // given
+        List<MenuPermission> permissions = List.of(new MenuPermission("v3_role_manage", "W"));
+        given(menuResourcePermissions.getDerivedResourceAuthorities("v3_role_manage", MenuAccessLevel.WRITE))
+                .willReturn(Set.of("RES_ROLE:R", "RES_ROLE:W", "RES_MENU:R"));
+
+        // when
+        Set<GrantedAuthority> result = converter.convert(permissions);
+
+        // then
+        assertThat(result)
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder(
+                        "v3_role_manage:R", "v3_role_manage:W", "RES_ROLE:R", "RES_ROLE:W", "RES_MENU:R");
+    }
+
+    @Test
+    @DisplayName("빈 권한 목록 변환 시 빈 Set을 반환한다")
+    void convert_empty_returns_empty_set() {
+        // given
+        List<MenuPermission> permissions = Collections.emptyList();
+
+        // when
+        Set<GrantedAuthority> result = converter.convert(permissions);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("YAML에 정의되지 않은 메뉴는 메뉴 권한만 반환한다")
+    void convert_unknown_menu_returns_only_menu_authorities() {
+        // given
+        List<MenuPermission> permissions = List.of(new MenuPermission("UNKNOWN_MENU", "W"));
+        given(menuResourcePermissions.getDerivedResourceAuthorities("UNKNOWN_MENU", MenuAccessLevel.WRITE))
+                .willReturn(Collections.emptySet());
+
+        // when
+        Set<GrantedAuthority> result = converter.convert(permissions);
+
+        // then
+        assertThat(result)
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("UNKNOWN_MENU:R", "UNKNOWN_MENU:W");
+    }
+
+    @Test
+    @DisplayName("여러 메뉴 권한을 한번에 변환한다")
+    void convert_multiple_permissions() {
+        // given
+        List<MenuPermission> permissions =
+                List.of(new MenuPermission("v3_menu_manage", "R"), new MenuPermission("v3_role_manage", "W"));
+        given(menuResourcePermissions.getDerivedResourceAuthorities("v3_menu_manage", MenuAccessLevel.READ))
+                .willReturn(Set.of("RES_MENU:R"));
+        given(menuResourcePermissions.getDerivedResourceAuthorities("v3_role_manage", MenuAccessLevel.WRITE))
+                .willReturn(Set.of("RES_ROLE:R", "RES_ROLE:W", "RES_MENU:R"));
+
+        // when
+        Set<GrantedAuthority> result = converter.convert(permissions);
+
+        // then
+        assertThat(result)
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder(
+                        "v3_menu_manage:R",
+                        "v3_role_manage:R",
+                        "v3_role_manage:W",
+                        "RES_MENU:R",
+                        "RES_ROLE:R",
+                        "RES_ROLE:W");
+    }
+}

--- a/src/test/java/org/example/springadminv2/security/MenuResourcePermissionsTest.java
+++ b/src/test/java/org/example/springadminv2/security/MenuResourcePermissionsTest.java
@@ -1,0 +1,122 @@
+package org.example.springadminv2.security;
+
+import java.util.List;
+import java.util.Set;
+
+import org.example.springadminv2.global.security.config.MenuResourcePermissions;
+import org.example.springadminv2.global.security.constant.MenuAccessLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MenuResourcePermissionsTest {
+
+    private final MenuResourcePermissions permissions = createPermissions();
+
+    private static MenuResourcePermissions createPermissions() {
+        MenuResourcePermissions p = new MenuResourcePermissions();
+        ReflectionTestUtils.invokeMethod(p, "init");
+        return p;
+    }
+
+    @Test
+    @DisplayName("READ 레벨 조회 시 READ 리소스만 반환한다")
+    void get_derived_read_returns_only_read_resources() {
+        // given
+        String menuId = "v3_role_manage";
+        MenuAccessLevel level = MenuAccessLevel.READ;
+
+        // when
+        Set<String> result = permissions.getDerivedResourceAuthorities(menuId, level);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder("RES_ROLE:R", "RES_MENU:R");
+    }
+
+    @Test
+    @DisplayName("WRITE 레벨 조회 시 READ + WRITE 리소스를 모두 반환한다")
+    void get_derived_write_returns_read_and_write_resources() {
+        // given
+        String menuId = "v3_role_manage";
+        MenuAccessLevel level = MenuAccessLevel.WRITE;
+
+        // when
+        Set<String> result = permissions.getDerivedResourceAuthorities(menuId, level);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder("RES_ROLE:R", "RES_MENU:R", "RES_ROLE:W");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 메뉴 ID 조회 시 빈 Set을 반환한다")
+    void get_derived_unknown_menu_returns_empty() {
+        // given
+        String menuId = "nonexistent_menu";
+        MenuAccessLevel level = MenuAccessLevel.WRITE;
+
+        // when
+        Set<String> result = permissions.getDerivedResourceAuthorities(menuId, level);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("permitAll/isAuthenticated 특수 값은 무시한다")
+    void special_values_are_ignored() {
+        // given – login, dashboard 등은 특수 값으로 정의됨
+        String loginMenu = "login";
+        String dashboardMenu = "dashboard";
+
+        // when
+        Set<String> loginResult = permissions.getDerivedResourceAuthorities(loginMenu, MenuAccessLevel.READ);
+        Set<String> dashboardResult = permissions.getDerivedResourceAuthorities(dashboardMenu, MenuAccessLevel.READ);
+
+        // then
+        assertThat(loginResult).isEmpty();
+        assertThat(dashboardResult).isEmpty();
+    }
+
+    @Test
+    @DisplayName("YAML 리소스 접미사가 :R/:W 형식으로 변환된다")
+    void yaml_suffix_converted_to_authority_format() {
+        // given
+        String menuId = "v3_menu_manage";
+
+        // when
+        Set<String> readResult = permissions.getDerivedResourceAuthorities(menuId, MenuAccessLevel.READ);
+        Set<String> writeResult = permissions.getDerivedResourceAuthorities(menuId, MenuAccessLevel.WRITE);
+
+        // then
+        assertThat(readResult).containsExactly("RES_MENU:R");
+        assertThat(writeResult).containsExactlyInAnyOrder("RES_MENU:R", "RES_MENU:W");
+    }
+
+    @Test
+    @DisplayName("WRITE 미정의 메뉴의 WRITE 조회 시 READ 리소스만 반환한다")
+    void write_undefined_menu_returns_only_read_on_write_level() {
+        // given – v3_db_log는 _WRITE가 정의되지 않음
+        String menuId = "v3_db_log";
+
+        // when
+        Set<String> result = permissions.getDerivedResourceAuthorities(menuId, MenuAccessLevel.WRITE);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder("RES_MESSAGEINSTANCE:R", "RES_ORG:R");
+    }
+
+    @Test
+    @DisplayName("접미사 없는 리소스명은 그대로 반환된다")
+    void resource_without_suffix_returned_as_is() {
+        // given
+        String rawValue = "PLAIN_RESOURCE";
+
+        // when
+        List<String> result = ReflectionTestUtils.invokeMethod(permissions, "parseResources", rawValue);
+
+        // then
+        assertThat(result).containsExactly("PLAIN_RESOURCE");
+    }
+}

--- a/src/test/java/org/example/springadminv2/security/PreAuthorizeSecurityTest.java
+++ b/src/test/java/org/example/springadminv2/security/PreAuthorizeSecurityTest.java
@@ -5,6 +5,7 @@ import org.example.springadminv2.global.security.SecurityConfig;
 import org.example.springadminv2.global.security.handler.CustomAccessDeniedHandler;
 import org.example.springadminv2.global.security.handler.CustomAuthenticationEntryPoint;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -29,73 +30,163 @@ class PreAuthorizeSecurityTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Test
-    @DisplayName("인증 없음 → 로그인 리다이렉트")
-    @WithAnonymousUser
-    void unauthenticated_redirectsToLogin() throws Exception {
-        mockMvc.perform(get("/test/menu001")).andExpect(status().is3xxRedirection());
+    @Nested
+    @DisplayName("메뉴 직접 권한")
+    class MenuDirectAuthority {
+
+        @Test
+        @DisplayName("인증 없음 → 로그인 리다이렉트")
+        @WithAnonymousUser
+        void unauthenticated_redirects_to_login() throws Exception {
+            // given – 인증되지 않은 사용자
+
+            // when & then
+            mockMvc.perform(get("/test/menu001")).andExpect(status().is3xxRedirection());
+        }
+
+        @Test
+        @DisplayName("READ 권한 → GET 성공")
+        @WithMockUser(authorities = "MENU001:R")
+        void read_authority_allows_get() throws Exception {
+            // given – MENU001:R 권한 보유
+
+            // when & then
+            mockMvc.perform(get("/test/menu001")).andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("READ 권한 → POST 403")
+        @WithMockUser(authorities = "MENU001:R")
+        void read_authority_denies_post() throws Exception {
+            // given – MENU001:R 권한만 보유
+
+            // when & then
+            mockMvc.perform(post("/test/menu001").with(csrf())).andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("READ 권한 → PUT 403")
+        @WithMockUser(authorities = "MENU001:R")
+        void read_authority_denies_put() throws Exception {
+            // given – MENU001:R 권한만 보유
+
+            // when & then
+            mockMvc.perform(put("/test/menu001").with(csrf())).andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("READ 권한 → DELETE 403")
+        @WithMockUser(authorities = "MENU001:R")
+        void read_authority_denies_delete() throws Exception {
+            // given – MENU001:R 권한만 보유
+
+            // when & then
+            mockMvc.perform(delete("/test/menu001").with(csrf())).andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("WRITE 권한 → GET 성공")
+        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        void write_authority_allows_get() throws Exception {
+            // given – MENU001:R, MENU001:W 권한 보유
+
+            // when & then
+            mockMvc.perform(get("/test/menu001")).andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("WRITE 권한 → POST 성공")
+        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        void write_authority_allows_post() throws Exception {
+            // given – MENU001:R, MENU001:W 권한 보유
+
+            // when & then
+            mockMvc.perform(post("/test/menu001").with(csrf())).andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("WRITE 권한 → PUT 성공")
+        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        void write_authority_allows_put() throws Exception {
+            // given – MENU001:R, MENU001:W 권한 보유
+
+            // when & then
+            mockMvc.perform(put("/test/menu001").with(csrf())).andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("WRITE 권한 → DELETE 성공")
+        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        void write_authority_allows_delete() throws Exception {
+            // given – MENU001:R, MENU001:W 권한 보유
+
+            // when & then
+            mockMvc.perform(delete("/test/menu001").with(csrf())).andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("다른 메뉴 권한 → 403")
+        @WithMockUser(authorities = "MENU999:R")
+        void wrong_menu_authority_returns_forbidden() throws Exception {
+            // given – 다른 메뉴 권한만 보유
+
+            // when & then
+            mockMvc.perform(get("/test/menu001")).andExpect(status().isForbidden());
+        }
     }
 
-    @Test
-    @DisplayName("READ 권한 → GET 성공")
-    @WithMockUser(authorities = "MENU001:R")
-    void readAuthority_getSuccess() throws Exception {
-        mockMvc.perform(get("/test/menu001")).andExpect(status().isOk());
-    }
+    @Nested
+    @DisplayName("크로스 리소스 권한")
+    class CrossResourceAuthority {
 
-    @Test
-    @DisplayName("READ 권한 → POST 403")
-    @WithMockUser(authorities = "MENU001:R")
-    void readAuthority_postForbidden() throws Exception {
-        mockMvc.perform(post("/test/menu001").with(csrf())).andExpect(status().isForbidden());
-    }
+        @Test
+        @DisplayName("직접 메뉴 권한으로 크로스 리소스 GET 성공")
+        @WithMockUser(authorities = "v3_was_instance:R")
+        void direct_menu_authority_allows_cross_resource_get() throws Exception {
+            // given – v3_was_instance:R 직접 메뉴 권한 보유
 
-    @Test
-    @DisplayName("READ 권한 → PUT 403")
-    @WithMockUser(authorities = "MENU001:R")
-    void readAuthority_putForbidden() throws Exception {
-        mockMvc.perform(put("/test/menu001").with(csrf())).andExpect(status().isForbidden());
-    }
+            // when & then
+            mockMvc.perform(get("/test/cross-resource")).andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("READ 권한 → DELETE 403")
-    @WithMockUser(authorities = "MENU001:R")
-    void readAuthority_deleteForbidden() throws Exception {
-        mockMvc.perform(delete("/test/menu001").with(csrf())).andExpect(status().isForbidden());
-    }
+        @Test
+        @DisplayName("파생 리소스 권한으로 크로스 리소스 GET 성공")
+        @WithMockUser(authorities = "RES_WASINSTANCE:R")
+        void derived_resource_authority_allows_cross_resource_get() throws Exception {
+            // given – RES_WASINSTANCE:R 파생 리소스 권한 보유
 
-    @Test
-    @DisplayName("WRITE 권한 → GET 성공")
-    @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
-    void writeAuthority_getSuccess() throws Exception {
-        mockMvc.perform(get("/test/menu001")).andExpect(status().isOk());
-    }
+            // when & then
+            mockMvc.perform(get("/test/cross-resource")).andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("WRITE 권한 → POST 성공")
-    @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
-    void writeAuthority_postSuccess() throws Exception {
-        mockMvc.perform(post("/test/menu001").with(csrf())).andExpect(status().isOk());
-    }
+        @Test
+        @DisplayName("파생 리소스 WRITE 권한으로 크로스 리소스 POST 성공")
+        @WithMockUser(authorities = "RES_WASINSTANCE:W")
+        void derived_resource_write_allows_cross_resource_post() throws Exception {
+            // given – RES_WASINSTANCE:W 파생 리소스 권한 보유
 
-    @Test
-    @DisplayName("WRITE 권한 → PUT 성공")
-    @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
-    void writeAuthority_putSuccess() throws Exception {
-        mockMvc.perform(put("/test/menu001").with(csrf())).andExpect(status().isOk());
-    }
+            // when & then
+            mockMvc.perform(post("/test/cross-resource").with(csrf())).andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("WRITE 권한 → DELETE 성공")
-    @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
-    void writeAuthority_deleteSuccess() throws Exception {
-        mockMvc.perform(delete("/test/menu001").with(csrf())).andExpect(status().isOk());
-    }
+        @Test
+        @DisplayName("관련 없는 권한으로 크로스 리소스 GET 403")
+        @WithMockUser(authorities = "MENU999:R")
+        void unrelated_authority_denies_cross_resource_get() throws Exception {
+            // given – 관련 없는 권한만 보유
 
-    @Test
-    @DisplayName("다른 메뉴 권한 → 403")
-    @WithMockUser(authorities = "MENU999:R")
-    void wrongMenuAuthority_forbidden() throws Exception {
-        mockMvc.perform(get("/test/menu001")).andExpect(status().isForbidden());
+            // when & then
+            mockMvc.perform(get("/test/cross-resource")).andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("READ 리소스 권한으로 크로스 리소스 POST 403")
+        @WithMockUser(authorities = "RES_WASINSTANCE:R")
+        void read_resource_denies_cross_resource_post() throws Exception {
+            // given – RES_WASINSTANCE:R만 보유 (WRITE 없음)
+
+            // when & then
+            mockMvc.perform(post("/test/cross-resource").with(csrf())).andExpect(status().isForbidden());
+        }
     }
 }

--- a/src/test/java/org/example/springadminv2/security/RoleMenuAuthorityProviderTest.java
+++ b/src/test/java/org/example/springadminv2/security/RoleMenuAuthorityProviderTest.java
@@ -3,15 +3,18 @@ package org.example.springadminv2.security;
 import java.util.List;
 import java.util.Set;
 
+import org.example.springadminv2.global.security.converter.AuthorityConverter;
 import org.example.springadminv2.global.security.dto.MenuPermission;
 import org.example.springadminv2.global.security.mapper.AuthorityMapper;
 import org.example.springadminv2.global.security.provider.RoleMenuAuthorityProvider;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -22,37 +25,42 @@ class RoleMenuAuthorityProviderTest {
     @Mock
     AuthorityMapper authorityMapper;
 
+    @Mock
+    AuthorityConverter authorityConverter;
+
     @InjectMocks
     RoleMenuAuthorityProvider provider;
 
     @Test
-    void write_permission_grants_both_read_and_write() {
-        given(authorityMapper.selectMenuPermissionsByRoleId("ROLE_ADMIN"))
-                .willReturn(List.of(new MenuPermission("MENU01", "W")));
+    @DisplayName("역할 기반 권한 조회 시 AuthorityConverter로 변환한 결과를 반환한다")
+    void get_authorities_delegates_to_converter() {
+        // given
+        List<MenuPermission> permissions = List.of(new MenuPermission("MENU01", "W"));
+        Set<GrantedAuthority> expected =
+                Set.of(new SimpleGrantedAuthority("MENU01:R"), new SimpleGrantedAuthority("MENU01:W"));
 
-        Set<GrantedAuthority> authorities = provider.getAuthorities("user01", "ROLE_ADMIN");
+        given(authorityMapper.selectMenuPermissionsByRoleId("ROLE_ADMIN")).willReturn(permissions);
+        given(authorityConverter.convert(permissions)).willReturn(expected);
 
-        assertThat(authorities)
-                .extracting(GrantedAuthority::getAuthority)
-                .containsExactlyInAnyOrder("MENU01:R", "MENU01:W");
+        // when
+        Set<GrantedAuthority> result = provider.getAuthorities("user01", "ROLE_ADMIN");
+
+        // then
+        assertThat(result).extracting(GrantedAuthority::getAuthority).containsExactlyInAnyOrder("MENU01:R", "MENU01:W");
     }
 
     @Test
-    void read_permission_grants_only_read() {
-        given(authorityMapper.selectMenuPermissionsByRoleId("ROLE_USER"))
-                .willReturn(List.of(new MenuPermission("MENU02", "R")));
+    @DisplayName("빈 권한 목록 시 빈 Set을 반환한다")
+    void get_authorities_empty_permissions_returns_empty() {
+        // given
+        List<MenuPermission> permissions = List.of();
+        given(authorityMapper.selectMenuPermissionsByRoleId("ROLE_NONE")).willReturn(permissions);
+        given(authorityConverter.convert(permissions)).willReturn(Set.of());
 
-        Set<GrantedAuthority> authorities = provider.getAuthorities("user01", "ROLE_USER");
+        // when
+        Set<GrantedAuthority> result = provider.getAuthorities("user01", "ROLE_NONE");
 
-        assertThat(authorities).extracting(GrantedAuthority::getAuthority).containsExactly("MENU02:R");
-    }
-
-    @Test
-    void empty_permissions_returns_empty_set() {
-        given(authorityMapper.selectMenuPermissionsByRoleId("ROLE_NONE")).willReturn(List.of());
-
-        Set<GrantedAuthority> authorities = provider.getAuthorities("user01", "ROLE_NONE");
-
-        assertThat(authorities).isEmpty();
+        // then
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/org/example/springadminv2/security/SampleSecuredController.java
+++ b/src/test/java/org/example/springadminv2/security/SampleSecuredController.java
@@ -6,34 +6,44 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/test/menu001")
 public class SampleSecuredController {
 
-    @GetMapping
+    @GetMapping("/test/menu001")
     @PreAuthorize("hasAuthority('MENU001:R')")
     public ResponseEntity<String> read() {
         return ResponseEntity.ok("read");
     }
 
-    @PostMapping
+    @PostMapping("/test/menu001")
     @PreAuthorize("hasAuthority('MENU001:W')")
     public ResponseEntity<String> create() {
         return ResponseEntity.ok("created");
     }
 
-    @PutMapping
+    @PutMapping("/test/menu001")
     @PreAuthorize("hasAuthority('MENU001:W')")
     public ResponseEntity<String> update() {
         return ResponseEntity.ok("updated");
     }
 
-    @DeleteMapping
+    @DeleteMapping("/test/menu001")
     @PreAuthorize("hasAuthority('MENU001:W')")
     public ResponseEntity<String> delete() {
         return ResponseEntity.ok("deleted");
+    }
+
+    @GetMapping("/test/cross-resource")
+    @PreAuthorize("hasAnyAuthority('v3_was_instance:R', 'RES_WASINSTANCE:R')")
+    public ResponseEntity<String> crossResourceRead() {
+        return ResponseEntity.ok("cross-resource-read");
+    }
+
+    @PostMapping("/test/cross-resource")
+    @PreAuthorize("hasAnyAuthority('v3_was_instance:W', 'RES_WASINSTANCE:W')")
+    public ResponseEntity<String> crossResourceWrite() {
+        return ResponseEntity.ok("cross-resource-write");
     }
 }


### PR DESCRIPTION
## Summary
- `MenuResourcePermissions`: `menu-resource-permissions.yml`을 SnakeYAML로 로드하여 메뉴별 리소스 의존성 조회 (`RES_XXX_READ` → `RES_XXX:R` 형식 변환)
- `AuthorityConverter`: 메뉴 권한 변환 + YAML 기반 리소스 파생을 통합하여 크로스 리소스 참조 시 403 발생 문제 해결
- `RoleMenuAuthorityProvider`, `UserMenuAuthorityProvider`의 중복 `toGrantedAuthorities` 로직을 `AuthorityConverter`로 위임
- `SampleSecuredController`에 `hasAnyAuthority` 크로스 리소스 엔드포인트 추가, `PreAuthorizeSecurityTest`에 리소스 권한 테스트 추가
- 전체 테스트 Given-When-Then + `@DisplayName` + `snake_case` 컨벤션 통일

## JaCoCo 커버리지 리포트

| 계층 | 커버리지 | 기준 |
|------|----------|------|
| Security (전체) | 153/161 lines (95%) | 90% |
| ┗ security.config | 44/48 (92%) | 90% |
| ┗ security.converter | 13/13 (100%) | 90% |
| ┗ security.provider | 4/4 (100%) | 90% |
| ┗ security.handler | 51/55 (93%) | 90% |
| ┗ security (core) | 32/32 (100%) | 90% |
| ┗ security.constant | 7/7 (100%) | 90% |
| ┗ security.dto | 2/2 (100%) | 90% |
| Logging | 43/43 lines (100%) | 90% |
| Util | 2/2 lines (100%) | 90% |
| Exception | 92/93 lines (99%) | — |
| Config | 16/16 lines (100%) | — |
| **전체** | **309/320 lines (97%)** | **55%** |

## Test plan
- [x] `MenuResourcePermissionsTest` — YAML 로딩, READ/WRITE 리소스 조회, 특수 값 무시, 접미사 변환 (7건)
- [x] `AuthorityConverterTest` — 메뉴 권한 변환, 리소스 파생, WRITE⊃READ, 빈 권한, 다중 메뉴 (5건)
- [x] `RoleMenuAuthorityProviderTest` — AuthorityConverter 위임 검증 (2건)
- [x] `PreAuthorizeSecurityTest` — 직접 메뉴 권한 (10건) + 크로스 리소스 권한 (5건)
- [x] 전체 85개 테스트 통과
- [x] `mvn verify` JaCoCo 커버리지 체크 통과
- [x] Spotless 포매팅 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)