### PR TITLE
refactor#45: 리소스 기반 단일 권한 체계 전환

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
             <version>${logstash-logback.version}</version>
         </dependency>
 
+        <!-- ── Excel ── -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
+        </dependency>
+
         <!-- ── Lombok ── -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/frontend/src/input.css
+++ b/src/main/frontend/src/input.css
@@ -1,3 +1,51 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ── 인쇄 스타일 ── */
+@media print {
+    .no-print,
+    nav,
+    aside,
+    .sidebar,
+    .search-filter,
+    .pagination,
+    .btn-area {
+        display: none !important;
+    }
+
+    body {
+        background: #fff !important;
+        color: #000 !important;
+        font-size: 12pt;
+    }
+
+    table {
+        width: 100% !important;
+        border-collapse: collapse;
+    }
+
+    table th,
+    table td {
+        border: 1px solid #000 !important;
+        padding: 4px 8px;
+        color: #000 !important;
+        background: #fff !important;
+    }
+
+    table th {
+        font-weight: bold;
+    }
+
+    tr {
+        page-break-inside: avoid;
+    }
+
+    thead {
+        display: table-header-group;
+    }
+
+    @page {
+        margin: 1.5cm;
+    }
+}

--- a/src/main/java/org/example/springadminv2/global/dto/DateRangeResult.java
+++ b/src/main/java/org/example/springadminv2/global/dto/DateRangeResult.java
@@ -1,0 +1,5 @@
+package org.example.springadminv2.global.dto;
+
+import java.time.LocalDate;
+
+public record DateRangeResult(LocalDate startDate, LocalDate endDate) {}

--- a/src/main/java/org/example/springadminv2/global/dto/ExcelColumnDefinition.java
+++ b/src/main/java/org/example/springadminv2/global/dto/ExcelColumnDefinition.java
@@ -1,0 +1,3 @@
+package org.example.springadminv2.global.dto;
+
+public record ExcelColumnDefinition(String header, String fieldName, int width) {}

--- a/src/main/java/org/example/springadminv2/global/security/config/MenuResourcePermissions.java
+++ b/src/main/java/org/example/springadminv2/global/security/config/MenuResourcePermissions.java
@@ -1,99 +1,38 @@
 package org.example.springadminv2.global.security.config;
 
-import java.io.InputStream;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.example.springadminv2.global.security.constant.MenuAccessLevel;
-import org.springframework.stereotype.Component;
-import org.yaml.snakeyaml.Yaml;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import jakarta.annotation.PostConstruct;
-
-@Component
+@ConfigurationProperties(prefix = "menu-resource")
 public class MenuResourcePermissions {
 
-    private static final String YAML_PATH = "menu-resource-permissions.yml";
-    private static final String READ_SUFFIX = "_READ";
-    private static final String WRITE_SUFFIX = "_WRITE";
-    private static final Set<String> SPECIAL_VALUES = Set.of("permitAll", "isAuthenticated");
+    private Map<String, Map<String, String>> permissions = Collections.emptyMap();
 
-    private final Map<String, List<String>> readResources = new HashMap<>();
-    private final Map<String, List<String>> writeResources = new HashMap<>();
+    public Map<String, Map<String, String>> getPermissions() {
+        return permissions;
+    }
 
-    @PostConstruct
-    void init() {
-        Yaml yaml = new Yaml();
-        try (InputStream is = getClass().getClassLoader().getResourceAsStream(YAML_PATH)) {
-            if (is == null) {
-                throw new IllegalStateException("Resource not found: " + YAML_PATH);
-            }
-            Map<String, String> entries = yaml.load(is);
-            if (entries == null) {
-                return;
-            }
-            for (Map.Entry<String, String> entry : entries.entrySet()) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-
-                if (SPECIAL_VALUES.contains(value)) {
-                    continue;
-                }
-
-                if (key.endsWith(READ_SUFFIX)) {
-                    String menuId = key.substring(0, key.length() - READ_SUFFIX.length());
-                    readResources.put(menuId, parseResources(value));
-                } else if (key.endsWith(WRITE_SUFFIX)) {
-                    String menuId = key.substring(0, key.length() - WRITE_SUFFIX.length());
-                    writeResources.put(menuId, parseResources(value));
-                }
-            }
-        } catch (java.io.IOException e) {
-            throw new IllegalStateException("Failed to load " + YAML_PATH, e);
-        }
+    public void setPermissions(Map<String, Map<String, String>> permissions) {
+        this.permissions = permissions;
     }
 
     public Set<String> getDerivedResourceAuthorities(String menuId, MenuAccessLevel level) {
-        Set<String> authorities = new HashSet<>();
+        Map<String, String> entry = permissions.getOrDefault(menuId, Collections.emptyMap());
 
-        List<String> reads = readResources.getOrDefault(menuId, Collections.emptyList());
-        authorities.addAll(reads);
+        String readValue = entry.getOrDefault("R", "");
+        String writeValue = level == MenuAccessLevel.WRITE ? entry.getOrDefault("W", "") : "";
 
-        if (level == MenuAccessLevel.WRITE) {
-            List<String> writes = writeResources.getOrDefault(menuId, Collections.emptyList());
-            authorities.addAll(writes);
-        }
+        String combined = readValue + "," + writeValue;
 
-        return authorities;
-    }
-
-    private List<String> parseResources(String value) {
-        List<String> resources = new ArrayList<>();
-        for (String token : value.split(",")) {
-            String trimmed = token.trim();
-            if (!trimmed.isEmpty()) {
-                resources.add(toAuthorityFormat(trimmed));
-            }
-        }
-        return resources;
-    }
-
-    private String toAuthorityFormat(String yamlResource) {
-        if (yamlResource.endsWith(READ_SUFFIX)) {
-            return yamlResource.substring(0, yamlResource.length() - READ_SUFFIX.length())
-                    + ":"
-                    + MenuAccessLevel.READ.getCode();
-        }
-        if (yamlResource.endsWith(WRITE_SUFFIX)) {
-            return yamlResource.substring(0, yamlResource.length() - WRITE_SUFFIX.length())
-                    + ":"
-                    + MenuAccessLevel.WRITE.getCode();
-        }
-        return yamlResource;
+        return Arrays.stream(combined.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/org/example/springadminv2/global/security/converter/AuthorityConverter.java
+++ b/src/main/java/org/example/springadminv2/global/security/converter/AuthorityConverter.java
@@ -26,11 +26,6 @@ public class AuthorityConverter {
             MenuAccessLevel level = MenuAccessLevel.fromCode(permission.authCode());
             String menuId = permission.menuId();
 
-            authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.READ.getCode()));
-            if (level == MenuAccessLevel.WRITE) {
-                authorities.add(new SimpleGrantedAuthority(menuId + ":" + MenuAccessLevel.WRITE.getCode()));
-            }
-
             Set<String> derivedResources = menuResourcePermissions.getDerivedResourceAuthorities(menuId, level);
             for (String resource : derivedResources) {
                 authorities.add(new SimpleGrantedAuthority(resource));

--- a/src/main/java/org/example/springadminv2/global/util/DateRangeUtil.java
+++ b/src/main/java/org/example/springadminv2/global/util/DateRangeUtil.java
@@ -1,0 +1,43 @@
+package org.example.springadminv2.global.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.example.springadminv2.global.dto.DateRangeResult;
+
+public final class DateRangeUtil {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private DateRangeUtil() {}
+
+    public static DateRangeResult defaultRange(ScreenDateType screenDateType, LocalDate today) {
+        LocalDate startDate = today.minusDays(screenDateType.getDaysBack());
+        return new DateRangeResult(startDate, today);
+    }
+
+    public static boolean isValidRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            return false;
+        }
+        return !startDate.isAfter(endDate);
+    }
+
+    public static String formatDate(LocalDate date) {
+        return date.format(DATE_FORMAT);
+    }
+
+    public static String formatDateTime(LocalDateTime dateTime) {
+        return dateTime.format(DATE_TIME_FORMAT);
+    }
+
+    public static LocalDate parseDate(String dateStr) {
+        return LocalDate.parse(dateStr, DATE_FORMAT);
+    }
+
+    public static LocalDateTime parseDateTime(String dateTimeStr) {
+        return LocalDateTime.parse(dateTimeStr, DATE_TIME_FORMAT);
+    }
+}

--- a/src/main/java/org/example/springadminv2/global/util/ExcelExportUtil.java
+++ b/src/main/java/org/example/springadminv2/global/util/ExcelExportUtil.java
@@ -1,0 +1,103 @@
+package org.example.springadminv2.global.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.example.springadminv2.global.dto.ExcelColumnDefinition;
+
+public final class ExcelExportUtil {
+
+    public static final int MAX_ROW_LIMIT = 10_000;
+
+    private static final DateTimeFormatter FILE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private ExcelExportUtil() {}
+
+    public static String generateFileName(String screenName, LocalDate date) {
+        return screenName + "_" + date.format(FILE_DATE_FORMAT) + ".xlsx";
+    }
+
+    public static boolean isWithinLimit(int count) {
+        return count <= MAX_ROW_LIMIT;
+    }
+
+    public static byte[] createWorkbook(
+            String sheetName, List<ExcelColumnDefinition> columns, List<Map<String, Object>> dataList)
+            throws IOException {
+
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet(sheetName);
+
+            CellStyle headerStyle = createHeaderStyle(workbook);
+            CellStyle dataStyle = createDataStyle(workbook);
+
+            // Header row
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < columns.size(); i++) {
+                ExcelColumnDefinition col = columns.get(i);
+                var cell = headerRow.createCell(i);
+                cell.setCellValue(col.header());
+                cell.setCellStyle(headerStyle);
+                sheet.setColumnWidth(i, col.width() * 256);
+            }
+
+            // Data rows
+            for (int rowIdx = 0; rowIdx < dataList.size(); rowIdx++) {
+                Map<String, Object> rowData = dataList.get(rowIdx);
+                Row row = sheet.createRow(rowIdx + 1);
+
+                for (int colIdx = 0; colIdx < columns.size(); colIdx++) {
+                    ExcelColumnDefinition col = columns.get(colIdx);
+                    Object value = rowData.get(col.fieldName());
+                    var cell = row.createCell(colIdx);
+                    cell.setCellValue(value != null ? value.toString() : "");
+                    cell.setCellStyle(dataStyle);
+                }
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            workbook.write(out);
+            return out.toByteArray();
+        }
+    }
+
+    private static CellStyle createHeaderStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+        style.setAlignment(HorizontalAlignment.CENTER);
+        style.setBorderBottom(BorderStyle.THIN);
+        style.setBorderTop(BorderStyle.THIN);
+        style.setBorderLeft(BorderStyle.THIN);
+        style.setBorderRight(BorderStyle.THIN);
+
+        Font font = workbook.createFont();
+        font.setBold(true);
+        style.setFont(font);
+
+        return style;
+    }
+
+    private static CellStyle createDataStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setBorderBottom(BorderStyle.THIN);
+        style.setBorderTop(BorderStyle.THIN);
+        style.setBorderLeft(BorderStyle.THIN);
+        style.setBorderRight(BorderStyle.THIN);
+        return style;
+    }
+}

--- a/src/main/java/org/example/springadminv2/global/util/ScreenDateType.java
+++ b/src/main/java/org/example/springadminv2/global/util/ScreenDateType.java
@@ -1,0 +1,19 @@
+package org.example.springadminv2.global.util;
+
+public enum ScreenDateType {
+    HISTORY_AUDIT(30),
+    BATCH_EXECUTION(0),
+    TRANSACTION_TRACE(1),
+    ERROR_LOG(7),
+    SYSTEM_MONITOR(0);
+
+    private final int daysBack;
+
+    ScreenDateType(int daysBack) {
+        this.daysBack = daysBack;
+    }
+
+    public int getDaysBack() {
+        return daysBack;
+    }
+}

--- a/src/main/resources/application-base.yml
+++ b/src/main/resources/application-base.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:menu-resource-permissions.yml
   application:
     name: spring-admin-v2
   thymeleaf:

--- a/src/main/resources/menu-resource-permissions.yml
+++ b/src/main/resources/menu-resource-permissions.yml
@@ -1,180 +1,185 @@
 # ==============================================================================
-# 메뉴별 리소스 의존성 (resource-dependencies)
+# 메뉴별 리소스 권한 매핑 (Menu-Resource Permissions)
 # ==============================================================================
 #
-# 각 화면의 권한 수준별 필요 리소스 목록
-#
-# - 키           : v3-menu-insert.sql MENU_ID 기준
-# - RES_XXX      : Package Structure.md 도메인 패키지명 (대문자)
-# - _READ        : 조회 시 필요한 리소스
-# - _WRITE       : 등록/수정/삭제 시 필요한 리소스
-# - _WRITE 미정의 = 조회 전용 (Template B/C)
+# - 키(1depth) : menu-resource.permissions.<MENU_ID>
+# - 키(2depth) : R = 조회, W = 등록/수정/삭제
+# - 값         : 최종 GrantedAuthority (콤마 구분)
+# - permitAll / isAuthenticated 메뉴는 YAML에서 제외 (빈 Set 반환)
 # ==============================================================================
 
+menu-resource:
+  permissions:
+
+    # ── 시스템 관리 (5개) ─────────────────────────────────────────────────────
+    v3_menu_manage:
+      R: "MENU:R"
+      W: "MENU:W"
+
+    v3_role_manage:
+      R: "ROLE:R, MENU:R"
+      W: "ROLE:W, MENU:R"
+
+    v3_user_manage:
+      R: "USER:R, ROLE:R"
+      W: "USER:W, ROLE:R"
+
+    v3_neb_code_group_manage:
+      R: "CODEGROUP:R"
+      W: "CODEGROUP:W"
+
+    v3_code_manage:
+      R: "CODE:R, CODEGROUP:R"
+      W: "CODE:W, CODEGROUP:R"
+
+    # ── 인프라 관리 (5개) ─────────────────────────────────────────────────────
+    v3_was_group_manage:
+      R: "WASGROUP:R"
+      W: "WASGROUP:W"
+
+    v3_was_instance:
+      R: "WASINSTANCE:R, WASGROUP:R"
+      W: "WASINSTANCE:W, WASGROUP:R"
 
-# ── 인증 (2개) ────────────────────────────────────────────────────────────────
+    v3_property_db_manage:
+      R: "PROPERTY:R, WASINSTANCE:R"
+      W: "PROPERTY:W, WASINSTANCE:R"
 
-login: permitAll
-v3_my_info_manage: isAuthenticated                         # 본인 정보만 (Principal 기반)
+    v3_xml_property_manage:
+      R: "XMLPROPERTY:R, WASINSTANCE:R"
+      W: "XMLPROPERTY:W, WASINSTANCE:R"
 
+    v3_system_oper_manage:
+      R: "RELOAD:R, WASINSTANCE:R"
+      W: "RELOAD:W, WASINSTANCE:R"
 
-# ── 홈 (1개) ──────────────────────────────────────────────────────────────────
+    # ── 연계 관리 (7개) ──────────────────────────────────────────────────────
+    v3_connect_org_manage:
+      R: "ORG:R, GATEWAY:R, MESSAGEHANDLER:R"
+      W: "ORG:W, GATEWAY:R, MESSAGEHANDLER:R"
+
+    v3_code_mapping_manage:
+      R: "CODE:R, ORG:R, CODEGROUP:R"
+      W: "CODE:W, ORG:R, CODEGROUP:R"
+
+    v3_gw_manage:
+      R: "GATEWAY:R, ORG:R"
+      W: "GATEWAY:W, ORG:R"
+
+    v3_org_trans_manage:
+      R: "GWSYSTEM:R, GATEWAY:R, ORG:R, TRANSACTION:R"
+      W: "GWSYSTEM:W, GATEWAY:R, ORG:R, TRANSACTION:R"
+
+    v3_app_mapping_manage:
+      R: "TRANSPORT:R, TRANSACTION:R, WASINSTANCE:R, GATEWAY:R"
+      W: "TRANSPORT:W, TRANSACTION:R, WASINSTANCE:R, GATEWAY:R, RELOAD:W"
+
+    v3_listener_connector_manage:
+      R: "LISTENERTRX:R, GATEWAY:R"
+      W: "LISTENERTRX:W, GATEWAY:R"
+
+    v3_msg_handle_manage:
+      R: "MESSAGEHANDLER:R"
+      W: "MESSAGEHANDLER:W"
+
+    # ── 거래/전문 관리 (7개) ──────────────────────────────────────────────────
+    v3_message_manage:
+      R: "MESSAGE:R, ORG:R"
+      W: "MESSAGE:W, ORG:R"
+
+    v3_msg_trx_manage:
+      R: "TRANSACTION:R, WASGROUP:R, WASINSTANCE:R, ORG:R, MESSAGE:R"
+      W: "TRANSACTION:W, WASGROUP:R, WASINSTANCE:R, ORG:R, MESSAGE:R"
+
+    v3_trx_validator:
+      R: "VALIDATOR:R, TRANSACTION:R"
+      W: "VALIDATOR:W, TRANSACTION:R"
+
+    v3_trx:
+      R: "TRANSACTION:R"
+      W: "TRANSACTION:W, WASINSTANCE:R, RELOAD:W"
+
+    v3_req_message_test:
+      R: "MESSAGETEST:R, ORG:R, TRANSACTION:R, WASINSTANCE:R"
+      W: "MESSAGETEST:W, ORG:R, TRANSACTION:R, WASINSTANCE:R"
+
+    v3_proxy_testdata:
+      R: "PROXYRESPONSE:R, TRANSACTION:R"
+      W: "PROXYRESPONSE:W, TRANSACTION:R"
+
+    v3_db_log:
+      R: "MESSAGEINSTANCE:R, ORG:R"
 
-dashboard: isAuthenticated                                 # 전용 집계 API
+    # ── 배치 관리 (3개) ──────────────────────────────────────────────────────
+    v3_batch_app_manage:
+      R: "BATCH:R, WASINSTANCE:R"
+      W: "BATCH:W, WASINSTANCE:R"
 
+    v3_batch_his_list:
+      R: "BATCH:R, WASINSTANCE:R"
 
-# ── 시스템 관리 (5개) ─────────────────────────────────────────────────────────
+    v3_executing_batch:
+      R: "BATCH:R"
 
-v3_menu_manage_READ: RES_MENU_READ
-v3_menu_manage_WRITE: RES_MENU_WRITE
+    # ── 오류 관리 (2개) ──────────────────────────────────────────────────────
+    v3_error_code:
+      R: "ERRORCODE:R"
+      W: "ERRORCODE:W"
 
-v3_role_manage_READ: RES_ROLE_READ, RES_MENU_READ
-v3_role_manage_WRITE: RES_ROLE_WRITE, RES_MENU_READ
+    v3_error_cause_his:
+      R: "ERRORHISTORY:R"
 
-v3_user_manage_READ: RES_USER_READ, RES_ROLE_READ
-v3_user_manage_WRITE: RES_USER_WRITE, RES_ROLE_READ
+    # ── 모니터링 (3개) ───────────────────────────────────────────────────────
+    v3_system_biz_reg:
+      R: "MONITOR:R"
+      W: "MONITOR:W"
 
-v3_neb_code_group_manage_READ: RES_CODEGROUP_READ
-v3_neb_code_group_manage_WRITE: RES_CODEGROUP_WRITE
+    v3_was_status:
+      R: "MONITOR:R, WASINSTANCE:R"
 
-v3_code_manage_READ: RES_CODE_READ, RES_CODEGROUP_READ
-v3_code_manage_WRITE: RES_CODE_WRITE, RES_CODEGROUP_READ
+    v3_was_status_monitor:
+      R: "MONITOR:R, WASINSTANCE:R"
 
+    # ── 이력/감사 (2개) ──────────────────────────────────────────────────────
+    v3_user_page_log:
+      R: "ADMINHISTORY:R, USER:R"
 
-# ── 인프라 관리 (5개) ─────────────────────────────────────────────────────────
+    v3_trx_stop_his:
+      R: "TRANSACTION:R"
 
-v3_was_group_manage_READ: RES_WASGROUP_READ
-v3_was_group_manage_WRITE: RES_WASGROUP_WRITE
+    # ── 게시판 (4개) ─────────────────────────────────────────────────────────
+    v3_board_manage:
+      R: "BOARD:R"
+      W: "BOARD:W"
 
-v3_was_instance_READ: RES_WASINSTANCE_READ, RES_WASGROUP_READ
-v3_was_instance_WRITE: RES_WASINSTANCE_WRITE, RES_WASGROUP_READ
+    v3_BOARD_AUTH:
+      R: "BOARD:R, USER:R"
+      W: "BOARD:W, USER:R"
 
-v3_property_db_manage_READ: RES_PROPERTY_READ, RES_WASINSTANCE_READ
-v3_property_db_manage_WRITE: RES_PROPERTY_WRITE, RES_WASINSTANCE_READ
+    v3_FWKB_NOTICE_BOARD:
+      R: "ARTICLE:R"
+      W: "ARTICLE:W"
 
-v3_xml_property_manage_READ: RES_XMLPROPERTY_READ, RES_WASINSTANCE_READ
-v3_xml_property_manage_WRITE: RES_XMLPROPERTY_WRITE, RES_WASINSTANCE_READ
+    v3_FWKB_TEST_BOARD:
+      R: "ARTICLE:R"
+      W: "ARTICLE:W"
 
-v3_system_oper_manage_READ: RES_RELOAD_READ, RES_WASINSTANCE_READ
-v3_system_oper_manage_WRITE: RES_RELOAD_WRITE, RES_WASINSTANCE_READ
+    # ── 전송 데이터 (3개) ────────────────────────────────────────────────────
+    v3_trans_data_exec:
+      R: "TRANSDATA:R, ORG:R"
+      W: "TRANSDATA:W, ORG:R"
 
+    v3_trans_data_popup:
+      R: "TRANSDATA:R, ORG:R"
+      W: "TRANSDATA:W, ORG:R"
 
-# ── 연계 관리 (7개) ──────────────────────────────────────────────────────────
+    v3_trans_data_list:
+      R: "TRANSDATA:R"
+      W: "TRANSDATA:W"
 
-v3_connect_org_manage_READ: RES_ORG_READ, RES_GATEWAY_READ, RES_MESSAGEHANDLER_READ
-v3_connect_org_manage_WRITE: RES_ORG_WRITE, RES_GATEWAY_READ, RES_MESSAGEHANDLER_READ
+    # ── 개발 관리 (2개) ──────────────────────────────────────────────────────
+    v3_message_parsing_test:
+      R: "MESSAGEPARSING:R, ORG:R, MESSAGE:R"
 
-v3_code_mapping_manage_READ: RES_CODE_READ, RES_ORG_READ, RES_CODEGROUP_READ
-v3_code_mapping_manage_WRITE: RES_CODE_WRITE, RES_ORG_READ, RES_CODEGROUP_READ
-
-v3_gw_manage_READ: RES_GATEWAY_READ, RES_ORG_READ
-v3_gw_manage_WRITE: RES_GATEWAY_WRITE, RES_ORG_READ
-
-v3_org_trans_manage_READ: RES_GWSYSTEM_READ, RES_GATEWAY_READ, RES_ORG_READ, RES_TRANSACTION_READ
-v3_org_trans_manage_WRITE: RES_GWSYSTEM_WRITE, RES_GATEWAY_READ, RES_ORG_READ, RES_TRANSACTION_READ
-
-v3_app_mapping_manage_READ: RES_TRANSPORT_READ, RES_TRANSACTION_READ, RES_WASINSTANCE_READ, RES_GATEWAY_READ
-v3_app_mapping_manage_WRITE: RES_TRANSPORT_WRITE, RES_TRANSACTION_READ, RES_WASINSTANCE_READ, RES_GATEWAY_READ, RES_RELOAD_WRITE
-
-v3_listener_connector_manage_READ: RES_LISTENERTRX_READ, RES_GATEWAY_READ
-v3_listener_connector_manage_WRITE: RES_LISTENERTRX_WRITE, RES_GATEWAY_READ
-
-v3_msg_handle_manage_READ: RES_MESSAGEHANDLER_READ
-v3_msg_handle_manage_WRITE: RES_MESSAGEHANDLER_WRITE
-
-
-# ── 거래/전문 관리 (7개) ──────────────────────────────────────────────────────
-
-v3_message_manage_READ: RES_MESSAGE_READ, RES_ORG_READ
-v3_message_manage_WRITE: RES_MESSAGE_WRITE, RES_ORG_READ
-
-v3_msg_trx_manage_READ: RES_TRANSACTION_READ, RES_WASGROUP_READ, RES_WASINSTANCE_READ, RES_ORG_READ, RES_MESSAGE_READ
-v3_msg_trx_manage_WRITE: RES_TRANSACTION_WRITE, RES_WASGROUP_READ, RES_WASINSTANCE_READ, RES_ORG_READ, RES_MESSAGE_READ
-
-v3_trx_validator_READ: RES_VALIDATOR_READ, RES_TRANSACTION_READ
-v3_trx_validator_WRITE: RES_VALIDATOR_WRITE, RES_TRANSACTION_READ
-
-v3_trx_READ: RES_TRANSACTION_READ
-v3_trx_WRITE: RES_TRANSACTION_WRITE, RES_WASINSTANCE_READ, RES_RELOAD_WRITE
-
-v3_req_message_test_READ: RES_MESSAGETEST_READ, RES_ORG_READ, RES_TRANSACTION_READ, RES_WASINSTANCE_READ
-v3_req_message_test_WRITE: RES_MESSAGETEST_WRITE, RES_ORG_READ, RES_TRANSACTION_READ, RES_WASINSTANCE_READ
-
-v3_proxy_testdata_READ: RES_PROXYRESPONSE_READ, RES_TRANSACTION_READ
-v3_proxy_testdata_WRITE: RES_PROXYRESPONSE_WRITE, RES_TRANSACTION_READ
-
-v3_db_log_READ: RES_MESSAGEINSTANCE_READ, RES_ORG_READ    # 로그 관리 > 전문로그 조회(DB) 공유
-
-
-# ── 배치 관리 (3개) ──────────────────────────────────────────────────────────
-
-v3_batch_app_manage_READ: RES_BATCH_READ, RES_WASINSTANCE_READ
-v3_batch_app_manage_WRITE: RES_BATCH_WRITE, RES_WASINSTANCE_READ
-
-v3_batch_his_list_READ: RES_BATCH_READ, RES_WASINSTANCE_READ
-
-v3_executing_batch_READ: RES_BATCH_READ
-
-
-# ── 오류 관리 (2개) ──────────────────────────────────────────────────────────
-
-v3_error_code_READ: RES_ERRORCODE_READ
-v3_error_code_WRITE: RES_ERRORCODE_WRITE
-
-v3_error_cause_his_READ: RES_ERRORHISTORY_READ
-
-
-# ── 모니터링 (3개) ───────────────────────────────────────────────────────────
-
-v3_system_biz_reg_READ: RES_MONITOR_READ
-v3_system_biz_reg_WRITE: RES_MONITOR_WRITE
-
-v3_was_status_READ: RES_MONITOR_READ, RES_WASINSTANCE_READ
-
-v3_was_status_monitor_READ: RES_MONITOR_READ, RES_WASINSTANCE_READ
-
-
-# ── 이력/감사 (2개) ──────────────────────────────────────────────────────────
-
-v3_user_page_log_READ: RES_ADMINHISTORY_READ, RES_USER_READ
-
-v3_trx_stop_his_READ: RES_TRANSACTION_READ
-
-
-# ── 로그 관리 (1개) ──────────────────────────────────────────────────────────
-
-# v3_db_log — 거래/전문 관리 섹션에서 정의 (거래추적로그조회(DB) = 전문로그 조회(DB))
-
-
-# ── 게시판 (4개) ─────────────────────────────────────────────────────────────
-
-v3_board_manage_READ: RES_BOARD_READ
-v3_board_manage_WRITE: RES_BOARD_WRITE
-
-v3_BOARD_AUTH_READ: RES_BOARD_READ, RES_USER_READ
-v3_BOARD_AUTH_WRITE: RES_BOARD_WRITE, RES_USER_READ
-
-v3_FWKB_NOTICE_BOARD_READ: RES_ARTICLE_READ
-v3_FWKB_NOTICE_BOARD_WRITE: RES_ARTICLE_WRITE
-
-v3_FWKB_TEST_BOARD_READ: RES_ARTICLE_READ
-v3_FWKB_TEST_BOARD_WRITE: RES_ARTICLE_WRITE
-
-
-# ── 전송 데이터 (3개) ────────────────────────────────────────────────────────
-
-v3_trans_data_exec_READ: RES_TRANSDATA_READ, RES_ORG_READ
-v3_trans_data_exec_WRITE: RES_TRANSDATA_WRITE, RES_ORG_READ
-
-v3_trans_data_popup_READ: RES_TRANSDATA_READ, RES_ORG_READ
-v3_trans_data_popup_WRITE: RES_TRANSDATA_WRITE, RES_ORG_READ
-
-v3_trans_data_list_READ: RES_TRANSDATA_READ
-v3_trans_data_list_WRITE: RES_TRANSDATA_WRITE
-
-
-# ── 개발 관리 (2개) ──────────────────────────────────────────────────────────
-
-v3_message_parsing_test_READ: RES_MESSAGEPARSING_READ, RES_ORG_READ, RES_MESSAGE_READ
-
-v3_message_parsing_json_READ: RES_MESSAGEPARSING_READ
+    v3_message_parsing_json:
+      R: "MESSAGEPARSING:R"

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -499,3 +499,107 @@ video {
 [hidden]:where(:not([hidden="until-found"])) {
   display: none;
 }
+.\!container {
+  width: 100% !important;
+}
+.container {
+  width: 100%;
+}
+@media (min-width: 640px) {
+
+  .\!container {
+    max-width: 640px !important;
+  }
+
+  .container {
+    max-width: 640px;
+  }
+}
+@media (min-width: 768px) {
+
+  .\!container {
+    max-width: 768px !important;
+  }
+
+  .container {
+    max-width: 768px;
+  }
+}
+@media (min-width: 1024px) {
+
+  .\!container {
+    max-width: 1024px !important;
+  }
+
+  .container {
+    max-width: 1024px;
+  }
+}
+@media (min-width: 1280px) {
+
+  .\!container {
+    max-width: 1280px !important;
+  }
+
+  .container {
+    max-width: 1280px;
+  }
+}
+@media (min-width: 1536px) {
+
+  .\!container {
+    max-width: 1536px !important;
+  }
+
+  .container {
+    max-width: 1536px;
+  }
+}
+
+/* ── 인쇄 스타일 ── */
+@media print {
+    .no-print,
+    nav,
+    aside,
+    .sidebar,
+    .search-filter,
+    .pagination,
+    .btn-area {
+        display: none !important;
+    }
+
+    body {
+        background: #fff !important;
+        color: #000 !important;
+        font-size: 12pt;
+    }
+
+    table {
+        width: 100% !important;
+        border-collapse: collapse;
+    }
+
+    table th,
+    table td {
+        border: 1px solid #000 !important;
+        padding: 4px 8px;
+        color: #000 !important;
+        background: #fff !important;
+    }
+
+    table th {
+        font-weight: bold;
+    }
+
+    tr {
+        page-break-inside: avoid;
+    }
+
+    thead {
+        display: table-header-group;
+    }
+
+    @page {
+        margin: 1.5cm;
+    }
+}

--- a/src/main/resources/static/js/common/date-defaults.js
+++ b/src/main/resources/static/js/common/date-defaults.js
@@ -1,0 +1,69 @@
+/**
+ * SpiderDateDefaults — 날짜 기본값 설정 공통 모듈
+ */
+(function () {
+    'use strict';
+
+    const DATE_TYPES = {
+        HISTORY_AUDIT: 30,
+        BATCH_EXECUTION: 0,
+        TRANSACTION_TRACE: 1,
+        ERROR_LOG: 7,
+        SYSTEM_MONITOR: 0
+    };
+
+    function formatDate(date) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return year + '-' + month + '-' + day;
+    }
+
+    function calcStartDate(screenType) {
+        const daysBack = DATE_TYPES[screenType];
+        if (daysBack === undefined) {
+            return null;
+        }
+        const date = new Date();
+        date.setDate(date.getDate() - daysBack);
+        return date;
+    }
+
+    window.SpiderDateDefaults = {
+        init: function (screenType, startSelector, endSelector) {
+            const startDate = calcStartDate(screenType);
+            if (!startDate) {
+                return;
+            }
+
+            const endDate = new Date();
+            const $start = $(startSelector);
+            const $end = $(endSelector);
+
+            if ($start.length > 0) {
+                $start.val(formatDate(startDate));
+            }
+            if ($end.length > 0) {
+                $end.val(formatDate(endDate));
+            }
+
+            $start.off('change.spiderDate').on('change.spiderDate', function () {
+                const startVal = $start.val();
+                const endVal = $end.val();
+                if (startVal && endVal && startVal > endVal) {
+                    SpiderToast.warning('시작일이 종료일보다 클 수 없습니다.');
+                    $start.val(endVal);
+                }
+            });
+
+            $end.off('change.spiderDate').on('change.spiderDate', function () {
+                const startVal = $start.val();
+                const endVal = $end.val();
+                if (startVal && endVal && startVal > endVal) {
+                    SpiderToast.warning('종료일이 시작일보다 작을 수 없습니다.');
+                    $end.val(startVal);
+                }
+            });
+        }
+    };
+})();

--- a/src/main/resources/static/js/common/dialog.js
+++ b/src/main/resources/static/js/common/dialog.js
@@ -1,0 +1,105 @@
+/**
+ * SpiderDialog — 확인/에러 다이얼로그 공통 모듈
+ */
+(function () {
+    'use strict';
+
+    const OVERLAY_STYLE =
+        'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);' +
+        'display:flex;justify-content:center;align-items:center;z-index:10000;';
+
+    const DIALOG_STYLE =
+        'background:#fff;border-radius:0.5rem;padding:1.5rem;min-width:320px;max-width:480px;' +
+        'box-shadow:0 20px 60px rgba(0,0,0,0.3);';
+
+    const BTN_BASE =
+        'padding:0.5rem 1.25rem;border:none;border-radius:0.25rem;cursor:pointer;font-size:0.875rem;';
+
+    function createOverlay() {
+        const overlay = document.createElement('div');
+        overlay.style.cssText = OVERLAY_STYLE;
+        return overlay;
+    }
+
+    function closeOverlay(overlay) {
+        if (overlay && overlay.parentNode) {
+            overlay.parentNode.removeChild(overlay);
+        }
+    }
+
+    window.SpiderDialog = {
+        confirm: function (msg, onOk, onCancel) {
+            const overlay = createOverlay();
+            const dialog = document.createElement('div');
+            dialog.style.cssText = DIALOG_STYLE;
+
+            const message = document.createElement('p');
+            message.style.cssText = 'margin:0 0 1.5rem 0;font-size:0.95rem;line-height:1.5;';
+            message.textContent = msg;
+            dialog.appendChild(message);
+
+            const btnArea = document.createElement('div');
+            btnArea.style.cssText = 'display:flex;justify-content:flex-end;gap:0.5rem;';
+
+            const cancelBtn = document.createElement('button');
+            cancelBtn.textContent = '취소';
+            cancelBtn.style.cssText = BTN_BASE + 'background:#e5e7eb;color:#374151;';
+            $(cancelBtn).off('click').on('click', function () {
+                closeOverlay(overlay);
+                if (typeof onCancel === 'function') {
+                    onCancel();
+                }
+            });
+
+            const okBtn = document.createElement('button');
+            okBtn.textContent = '확인';
+            okBtn.style.cssText = BTN_BASE + 'background:#2563eb;color:#fff;';
+            $(okBtn).off('click').on('click', function () {
+                closeOverlay(overlay);
+                if (typeof onOk === 'function') {
+                    onOk();
+                }
+            });
+
+            btnArea.appendChild(cancelBtn);
+            btnArea.appendChild(okBtn);
+            dialog.appendChild(btnArea);
+            overlay.appendChild(dialog);
+            document.body.appendChild(overlay);
+        },
+
+        error: function (msg, detail) {
+            const overlay = createOverlay();
+            const dialog = document.createElement('div');
+            dialog.style.cssText = DIALOG_STYLE;
+
+            const title = document.createElement('p');
+            title.style.cssText = 'margin:0 0 0.5rem 0;font-weight:bold;color:#dc2626;font-size:1rem;';
+            title.textContent = msg;
+            dialog.appendChild(title);
+
+            if (detail) {
+                const detailEl = document.createElement('p');
+                detailEl.style.cssText =
+                    'margin:0 0 1.5rem 0;font-size:0.85rem;color:#6b7280;line-height:1.4;white-space:pre-wrap;';
+                detailEl.textContent = detail;
+                dialog.appendChild(detailEl);
+            }
+
+            const btnArea = document.createElement('div');
+            btnArea.style.cssText = 'display:flex;justify-content:flex-end;';
+
+            const closeBtn = document.createElement('button');
+            closeBtn.textContent = '닫기';
+            closeBtn.style.cssText = BTN_BASE + 'background:#dc2626;color:#fff;';
+            $(closeBtn).off('click').on('click', function () {
+                closeOverlay(overlay);
+            });
+
+            btnArea.appendChild(closeBtn);
+            dialog.appendChild(btnArea);
+            overlay.appendChild(dialog);
+            document.body.appendChild(overlay);
+        }
+    };
+})();

--- a/src/main/resources/static/js/common/excel-export.js
+++ b/src/main/resources/static/js/common/excel-export.js
@@ -1,0 +1,44 @@
+/**
+ * SpiderExcel — 엑셀 다운로드 공통 모듈
+ */
+(function () {
+    'use strict';
+
+    window.SpiderExcel = {
+        download: function (url, params, screenName) {
+            SpiderToast.info('엑셀 파일을 생성 중입니다...');
+
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: JSON.stringify(params),
+                contentType: 'application/json',
+                xhrFields: { responseType: 'blob' },
+                success: function (blob, _status, xhr) {
+                    let fileName = screenName + '.xlsx';
+                    const disposition = xhr.getResponseHeader('Content-Disposition');
+                    if (disposition) {
+                        const match = disposition.match(/filename[^;=\n]*=["']?([^"';\n]*)["']?/);
+                        if (match && match[1]) {
+                            fileName = decodeURIComponent(match[1]);
+                        }
+                    }
+
+                    const objectUrl = URL.createObjectURL(blob);
+                    const link = document.createElement('a');
+                    link.href = objectUrl;
+                    link.download = fileName;
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                    URL.revokeObjectURL(objectUrl);
+
+                    SpiderToast.success('엑셀 다운로드가 완료되었습니다.');
+                },
+                error: function (_xhr, _status, error) {
+                    SpiderToast.error('엑셀 다운로드에 실패했습니다: ' + error);
+                }
+            });
+        }
+    };
+})();

--- a/src/main/resources/static/js/common/print.js
+++ b/src/main/resources/static/js/common/print.js
@@ -1,0 +1,12 @@
+/**
+ * SpiderPrint — 인쇄 공통 모듈
+ */
+(function () {
+    'use strict';
+
+    window.SpiderPrint = {
+        printList: function () {
+            window.print();
+        }
+    };
+})();

--- a/src/main/resources/static/js/common/toast.js
+++ b/src/main/resources/static/js/common/toast.js
@@ -1,0 +1,77 @@
+/**
+ * SpiderToast — 토스트 알림 공통 모듈
+ */
+(function () {
+    'use strict';
+
+    const TOAST_CONTAINER_ID = 'spider-toast-container';
+    const AUTO_CLOSE_MS = 3000;
+
+    function getContainer() {
+        let container = document.getElementById(TOAST_CONTAINER_ID);
+        if (!container) {
+            container = document.createElement('div');
+            container.id = TOAST_CONTAINER_ID;
+            container.style.cssText =
+                'position:fixed;top:1rem;right:1rem;z-index:9999;display:flex;flex-direction:column;gap:0.5rem;';
+            document.body.appendChild(container);
+        }
+        return container;
+    }
+
+    function createToast(message, type, autoClose) {
+        const colors = {
+            success: 'background:#16a34a;color:#fff;',
+            error: 'background:#dc2626;color:#fff;',
+            warning: 'background:#f59e0b;color:#fff;',
+            info: 'background:#2563eb;color:#fff;'
+        };
+
+        const toast = document.createElement('div');
+        toast.style.cssText =
+            colors[type] +
+            'padding:0.75rem 1.25rem;border-radius:0.375rem;box-shadow:0 4px 6px rgba(0,0,0,0.1);' +
+            'min-width:250px;display:flex;justify-content:space-between;align-items:center;font-size:0.875rem;';
+
+        const span = document.createElement('span');
+        span.textContent = message;
+        toast.appendChild(span);
+
+        const closeBtn = document.createElement('button');
+        closeBtn.textContent = '\u00d7';
+        closeBtn.style.cssText = 'background:none;border:none;color:inherit;font-size:1.25rem;cursor:pointer;margin-left:1rem;';
+        $(closeBtn).off('click').on('click', function () {
+            removeToast(toast);
+        });
+        toast.appendChild(closeBtn);
+
+        getContainer().appendChild(toast);
+
+        if (autoClose) {
+            setTimeout(function () {
+                removeToast(toast);
+            }, AUTO_CLOSE_MS);
+        }
+    }
+
+    function removeToast(toast) {
+        if (toast && toast.parentNode) {
+            toast.parentNode.removeChild(toast);
+        }
+    }
+
+    window.SpiderToast = {
+        success: function (msg) {
+            createToast(msg, 'success', true);
+        },
+        error: function (msg) {
+            createToast(msg, 'error', false);
+        },
+        warning: function (msg) {
+            createToast(msg, 'warning', true);
+        },
+        info: function (msg) {
+            createToast(msg, 'info', true);
+        }
+    };
+})();

--- a/src/test/java/org/example/springadminv2/security/AuthorityConverterTest.java
+++ b/src/test/java/org/example/springadminv2/security/AuthorityConverterTest.java
@@ -29,29 +29,27 @@ class AuthorityConverterTest {
     AuthorityConverter converter;
 
     @Test
-    @DisplayName("READ 권한 변환 시 메뉴 READ + 파생 리소스를 반환한다")
-    void convert_read_returns_menu_read_and_derived_resources() {
+    @DisplayName("READ 권한 변환 시 파생 리소스만 반환한다")
+    void convert_read_returns_derived_resources_only() {
         // given
         List<MenuPermission> permissions = List.of(new MenuPermission("v3_menu_manage", "R"));
         given(menuResourcePermissions.getDerivedResourceAuthorities("v3_menu_manage", MenuAccessLevel.READ))
-                .willReturn(Set.of("RES_MENU:R"));
+                .willReturn(Set.of("MENU:R"));
 
         // when
         Set<GrantedAuthority> result = converter.convert(permissions);
 
         // then
-        assertThat(result)
-                .extracting(GrantedAuthority::getAuthority)
-                .containsExactlyInAnyOrder("v3_menu_manage:R", "RES_MENU:R");
+        assertThat(result).extracting(GrantedAuthority::getAuthority).containsExactlyInAnyOrder("MENU:R");
     }
 
     @Test
-    @DisplayName("WRITE 권한 변환 시 메뉴 READ+WRITE + 파생 리소스를 반환한다")
-    void convert_write_returns_menu_read_write_and_derived_resources() {
+    @DisplayName("WRITE 권한 변환 시 READ + WRITE 파생 리소스를 반환한다")
+    void convert_write_returns_read_and_write_derived_resources() {
         // given
         List<MenuPermission> permissions = List.of(new MenuPermission("v3_role_manage", "W"));
         given(menuResourcePermissions.getDerivedResourceAuthorities("v3_role_manage", MenuAccessLevel.WRITE))
-                .willReturn(Set.of("RES_ROLE:R", "RES_ROLE:W", "RES_MENU:R"));
+                .willReturn(Set.of("ROLE:R", "ROLE:W", "MENU:R"));
 
         // when
         Set<GrantedAuthority> result = converter.convert(permissions);
@@ -59,8 +57,7 @@ class AuthorityConverterTest {
         // then
         assertThat(result)
                 .extracting(GrantedAuthority::getAuthority)
-                .containsExactlyInAnyOrder(
-                        "v3_role_manage:R", "v3_role_manage:W", "RES_ROLE:R", "RES_ROLE:W", "RES_MENU:R");
+                .containsExactlyInAnyOrder("ROLE:R", "ROLE:W", "MENU:R");
     }
 
     @Test
@@ -77,8 +74,8 @@ class AuthorityConverterTest {
     }
 
     @Test
-    @DisplayName("YAML에 정의되지 않은 메뉴는 메뉴 권한만 반환한다")
-    void convert_unknown_menu_returns_only_menu_authorities() {
+    @DisplayName("YAML에 정의되지 않은 메뉴는 빈 Set을 반환한다")
+    void convert_unknown_menu_returns_empty() {
         // given
         List<MenuPermission> permissions = List.of(new MenuPermission("UNKNOWN_MENU", "W"));
         given(menuResourcePermissions.getDerivedResourceAuthorities("UNKNOWN_MENU", MenuAccessLevel.WRITE))
@@ -88,9 +85,7 @@ class AuthorityConverterTest {
         Set<GrantedAuthority> result = converter.convert(permissions);
 
         // then
-        assertThat(result)
-                .extracting(GrantedAuthority::getAuthority)
-                .containsExactlyInAnyOrder("UNKNOWN_MENU:R", "UNKNOWN_MENU:W");
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -100,9 +95,9 @@ class AuthorityConverterTest {
         List<MenuPermission> permissions =
                 List.of(new MenuPermission("v3_menu_manage", "R"), new MenuPermission("v3_role_manage", "W"));
         given(menuResourcePermissions.getDerivedResourceAuthorities("v3_menu_manage", MenuAccessLevel.READ))
-                .willReturn(Set.of("RES_MENU:R"));
+                .willReturn(Set.of("MENU:R"));
         given(menuResourcePermissions.getDerivedResourceAuthorities("v3_role_manage", MenuAccessLevel.WRITE))
-                .willReturn(Set.of("RES_ROLE:R", "RES_ROLE:W", "RES_MENU:R"));
+                .willReturn(Set.of("ROLE:R", "ROLE:W", "MENU:R"));
 
         // when
         Set<GrantedAuthority> result = converter.convert(permissions);
@@ -110,12 +105,6 @@ class AuthorityConverterTest {
         // then
         assertThat(result)
                 .extracting(GrantedAuthority::getAuthority)
-                .containsExactlyInAnyOrder(
-                        "v3_menu_manage:R",
-                        "v3_role_manage:R",
-                        "v3_role_manage:W",
-                        "RES_MENU:R",
-                        "RES_ROLE:R",
-                        "RES_ROLE:W");
+                .containsExactlyInAnyOrder("MENU:R", "ROLE:R", "ROLE:W");
     }
 }

--- a/src/test/java/org/example/springadminv2/security/AuthorityProviderTest.java
+++ b/src/test/java/org/example/springadminv2/security/AuthorityProviderTest.java
@@ -19,37 +19,37 @@ class AuthorityProviderTest {
     private AuthorityProvider authorityProvider;
 
     @Test
-    @DisplayName("USER_MENU 기반: userId로 권한 로딩")
+    @DisplayName("USER_MENU 기반: userId로 리소스 권한 로딩")
     void loadAuthoritiesByUserId() {
         Set<GrantedAuthority> authorities = authorityProvider.getAuthorities("admin", "ADMIN");
 
         Set<String> authorityStrings =
                 authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
 
-        assertThat(authorityStrings).contains("MENU001:R", "MENU001:W", "MENU002:R", "MENU002:W");
+        assertThat(authorityStrings).contains("MENU:R", "MENU:W", "ROLE:R", "ROLE:W");
     }
 
     @Test
-    @DisplayName("WRITE → READ + WRITE 자동 확장")
+    @DisplayName("WRITE → READ + WRITE 리소스 자동 확장")
     void writeIncludesRead() {
         Set<GrantedAuthority> authorities = authorityProvider.getAuthorities("admin", "ADMIN");
 
         Set<String> authorityStrings =
                 authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
 
-        assertThat(authorityStrings).contains("MENU001:R", "MENU001:W");
+        assertThat(authorityStrings).contains("MENU:R", "MENU:W");
     }
 
     @Test
-    @DisplayName("READ 전용 사용자: READ만 포함, WRITE 미포함")
+    @DisplayName("READ 전용 사용자: READ 리소스만 포함, WRITE 미포함")
     void readOnlyUser() {
         Set<GrantedAuthority> authorities = authorityProvider.getAuthorities("user01", "USER");
 
         Set<String> authorityStrings =
                 authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
 
-        assertThat(authorityStrings).contains("MENU001:R");
-        assertThat(authorityStrings).doesNotContain("MENU001:W");
+        assertThat(authorityStrings).contains("MENU:R");
+        assertThat(authorityStrings).doesNotContain("MENU:W");
     }
 
     @Test

--- a/src/test/java/org/example/springadminv2/security/PreAuthorizeSecurityTest.java
+++ b/src/test/java/org/example/springadminv2/security/PreAuthorizeSecurityTest.java
@@ -31,8 +31,8 @@ class PreAuthorizeSecurityTest {
     private MockMvc mockMvc;
 
     @Nested
-    @DisplayName("메뉴 직접 권한")
-    class MenuDirectAuthority {
+    @DisplayName("리소스 기반 권한")
+    class ResourceAuthority {
 
         @Test
         @DisplayName("인증 없음 → 로그인 리다이렉트")
@@ -46,9 +46,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("READ 권한 → GET 성공")
-        @WithMockUser(authorities = "MENU001:R")
+        @WithMockUser(authorities = "SAMPLE:R")
         void read_authority_allows_get() throws Exception {
-            // given – MENU001:R 권한 보유
+            // given – SAMPLE:R 권한 보유
 
             // when & then
             mockMvc.perform(get("/test/menu001")).andExpect(status().isOk());
@@ -56,9 +56,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("READ 권한 → POST 403")
-        @WithMockUser(authorities = "MENU001:R")
+        @WithMockUser(authorities = "SAMPLE:R")
         void read_authority_denies_post() throws Exception {
-            // given – MENU001:R 권한만 보유
+            // given – SAMPLE:R 권한만 보유
 
             // when & then
             mockMvc.perform(post("/test/menu001").with(csrf())).andExpect(status().isForbidden());
@@ -66,9 +66,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("READ 권한 → PUT 403")
-        @WithMockUser(authorities = "MENU001:R")
+        @WithMockUser(authorities = "SAMPLE:R")
         void read_authority_denies_put() throws Exception {
-            // given – MENU001:R 권한만 보유
+            // given – SAMPLE:R 권한만 보유
 
             // when & then
             mockMvc.perform(put("/test/menu001").with(csrf())).andExpect(status().isForbidden());
@@ -76,9 +76,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("READ 권한 → DELETE 403")
-        @WithMockUser(authorities = "MENU001:R")
+        @WithMockUser(authorities = "SAMPLE:R")
         void read_authority_denies_delete() throws Exception {
-            // given – MENU001:R 권한만 보유
+            // given – SAMPLE:R 권한만 보유
 
             // when & then
             mockMvc.perform(delete("/test/menu001").with(csrf())).andExpect(status().isForbidden());
@@ -86,9 +86,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("WRITE 권한 → GET 성공")
-        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        @WithMockUser(authorities = {"SAMPLE:R", "SAMPLE:W"})
         void write_authority_allows_get() throws Exception {
-            // given – MENU001:R, MENU001:W 권한 보유
+            // given – SAMPLE:R, SAMPLE:W 권한 보유
 
             // when & then
             mockMvc.perform(get("/test/menu001")).andExpect(status().isOk());
@@ -96,9 +96,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("WRITE 권한 → POST 성공")
-        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        @WithMockUser(authorities = {"SAMPLE:R", "SAMPLE:W"})
         void write_authority_allows_post() throws Exception {
-            // given – MENU001:R, MENU001:W 권한 보유
+            // given – SAMPLE:R, SAMPLE:W 권한 보유
 
             // when & then
             mockMvc.perform(post("/test/menu001").with(csrf())).andExpect(status().isOk());
@@ -106,9 +106,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("WRITE 권한 → PUT 성공")
-        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        @WithMockUser(authorities = {"SAMPLE:R", "SAMPLE:W"})
         void write_authority_allows_put() throws Exception {
-            // given – MENU001:R, MENU001:W 권한 보유
+            // given – SAMPLE:R, SAMPLE:W 권한 보유
 
             // when & then
             mockMvc.perform(put("/test/menu001").with(csrf())).andExpect(status().isOk());
@@ -116,19 +116,19 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("WRITE 권한 → DELETE 성공")
-        @WithMockUser(authorities = {"MENU001:R", "MENU001:W"})
+        @WithMockUser(authorities = {"SAMPLE:R", "SAMPLE:W"})
         void write_authority_allows_delete() throws Exception {
-            // given – MENU001:R, MENU001:W 권한 보유
+            // given – SAMPLE:R, SAMPLE:W 권한 보유
 
             // when & then
             mockMvc.perform(delete("/test/menu001").with(csrf())).andExpect(status().isOk());
         }
 
         @Test
-        @DisplayName("다른 메뉴 권한 → 403")
-        @WithMockUser(authorities = "MENU999:R")
-        void wrong_menu_authority_returns_forbidden() throws Exception {
-            // given – 다른 메뉴 권한만 보유
+        @DisplayName("다른 리소스 권한 → 403")
+        @WithMockUser(authorities = "OTHER:R")
+        void wrong_resource_authority_returns_forbidden() throws Exception {
+            // given – 다른 리소스 권한만 보유
 
             // when & then
             mockMvc.perform(get("/test/menu001")).andExpect(status().isForbidden());
@@ -140,30 +140,20 @@ class PreAuthorizeSecurityTest {
     class CrossResourceAuthority {
 
         @Test
-        @DisplayName("직접 메뉴 권한으로 크로스 리소스 GET 성공")
-        @WithMockUser(authorities = "v3_was_instance:R")
-        void direct_menu_authority_allows_cross_resource_get() throws Exception {
-            // given – v3_was_instance:R 직접 메뉴 권한 보유
+        @DisplayName("리소스 권한으로 크로스 리소스 GET 성공")
+        @WithMockUser(authorities = "WASINSTANCE:R")
+        void resource_authority_allows_cross_resource_get() throws Exception {
+            // given – WASINSTANCE:R 리소스 권한 보유
 
             // when & then
             mockMvc.perform(get("/test/cross-resource")).andExpect(status().isOk());
         }
 
         @Test
-        @DisplayName("파생 리소스 권한으로 크로스 리소스 GET 성공")
-        @WithMockUser(authorities = "RES_WASINSTANCE:R")
-        void derived_resource_authority_allows_cross_resource_get() throws Exception {
-            // given – RES_WASINSTANCE:R 파생 리소스 권한 보유
-
-            // when & then
-            mockMvc.perform(get("/test/cross-resource")).andExpect(status().isOk());
-        }
-
-        @Test
-        @DisplayName("파생 리소스 WRITE 권한으로 크로스 리소스 POST 성공")
-        @WithMockUser(authorities = "RES_WASINSTANCE:W")
-        void derived_resource_write_allows_cross_resource_post() throws Exception {
-            // given – RES_WASINSTANCE:W 파생 리소스 권한 보유
+        @DisplayName("WRITE 리소스 권한으로 크로스 리소스 POST 성공")
+        @WithMockUser(authorities = "WASINSTANCE:W")
+        void resource_write_allows_cross_resource_post() throws Exception {
+            // given – WASINSTANCE:W 리소스 권한 보유
 
             // when & then
             mockMvc.perform(post("/test/cross-resource").with(csrf())).andExpect(status().isOk());
@@ -171,7 +161,7 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("관련 없는 권한으로 크로스 리소스 GET 403")
-        @WithMockUser(authorities = "MENU999:R")
+        @WithMockUser(authorities = "OTHER:R")
         void unrelated_authority_denies_cross_resource_get() throws Exception {
             // given – 관련 없는 권한만 보유
 
@@ -181,9 +171,9 @@ class PreAuthorizeSecurityTest {
 
         @Test
         @DisplayName("READ 리소스 권한으로 크로스 리소스 POST 403")
-        @WithMockUser(authorities = "RES_WASINSTANCE:R")
+        @WithMockUser(authorities = "WASINSTANCE:R")
         void read_resource_denies_cross_resource_post() throws Exception {
-            // given – RES_WASINSTANCE:R만 보유 (WRITE 없음)
+            // given – WASINSTANCE:R만 보유 (WRITE 없음)
 
             // when & then
             mockMvc.perform(post("/test/cross-resource").with(csrf())).andExpect(status().isForbidden());

--- a/src/test/java/org/example/springadminv2/security/SampleSecuredController.java
+++ b/src/test/java/org/example/springadminv2/security/SampleSecuredController.java
@@ -12,37 +12,37 @@ import org.springframework.web.bind.annotation.RestController;
 public class SampleSecuredController {
 
     @GetMapping("/test/menu001")
-    @PreAuthorize("hasAuthority('MENU001:R')")
+    @PreAuthorize("hasAuthority('SAMPLE:R')")
     public ResponseEntity<String> read() {
         return ResponseEntity.ok("read");
     }
 
     @PostMapping("/test/menu001")
-    @PreAuthorize("hasAuthority('MENU001:W')")
+    @PreAuthorize("hasAuthority('SAMPLE:W')")
     public ResponseEntity<String> create() {
         return ResponseEntity.ok("created");
     }
 
     @PutMapping("/test/menu001")
-    @PreAuthorize("hasAuthority('MENU001:W')")
+    @PreAuthorize("hasAuthority('SAMPLE:W')")
     public ResponseEntity<String> update() {
         return ResponseEntity.ok("updated");
     }
 
     @DeleteMapping("/test/menu001")
-    @PreAuthorize("hasAuthority('MENU001:W')")
+    @PreAuthorize("hasAuthority('SAMPLE:W')")
     public ResponseEntity<String> delete() {
         return ResponseEntity.ok("deleted");
     }
 
     @GetMapping("/test/cross-resource")
-    @PreAuthorize("hasAnyAuthority('v3_was_instance:R', 'RES_WASINSTANCE:R')")
+    @PreAuthorize("hasAuthority('WASINSTANCE:R')")
     public ResponseEntity<String> crossResourceRead() {
         return ResponseEntity.ok("cross-resource-read");
     }
 
     @PostMapping("/test/cross-resource")
-    @PreAuthorize("hasAnyAuthority('v3_was_instance:W', 'RES_WASINSTANCE:W')")
+    @PreAuthorize("hasAuthority('WASINSTANCE:W')")
     public ResponseEntity<String> crossResourceWrite() {
         return ResponseEntity.ok("cross-resource-write");
     }

--- a/src/test/java/org/example/springadminv2/util/DateRangeUtilTest.java
+++ b/src/test/java/org/example/springadminv2/util/DateRangeUtilTest.java
@@ -1,0 +1,136 @@
+package org.example.springadminv2.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.example.springadminv2.global.dto.DateRangeResult;
+import org.example.springadminv2.global.util.DateRangeUtil;
+import org.example.springadminv2.global.util.ScreenDateType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateRangeUtilTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2025, 3, 15);
+
+    @Nested
+    @DisplayName("defaultRange")
+    class DefaultRange {
+
+        @Test
+        @DisplayName("HISTORY_AUDIT — 30일 전부터 오늘까지")
+        void historyAudit() {
+            DateRangeResult result = DateRangeUtil.defaultRange(ScreenDateType.HISTORY_AUDIT, TODAY);
+            assertThat(result.startDate()).isEqualTo(LocalDate.of(2025, 2, 13));
+            assertThat(result.endDate()).isEqualTo(TODAY);
+        }
+
+        @Test
+        @DisplayName("BATCH_EXECUTION — 당일")
+        void batchExecution() {
+            DateRangeResult result = DateRangeUtil.defaultRange(ScreenDateType.BATCH_EXECUTION, TODAY);
+            assertThat(result.startDate()).isEqualTo(TODAY);
+            assertThat(result.endDate()).isEqualTo(TODAY);
+        }
+
+        @Test
+        @DisplayName("TRANSACTION_TRACE — 1일 전부터 오늘까지")
+        void transactionTrace() {
+            DateRangeResult result = DateRangeUtil.defaultRange(ScreenDateType.TRANSACTION_TRACE, TODAY);
+            assertThat(result.startDate()).isEqualTo(LocalDate.of(2025, 3, 14));
+            assertThat(result.endDate()).isEqualTo(TODAY);
+        }
+
+        @Test
+        @DisplayName("ERROR_LOG — 7일 전부터 오늘까지")
+        void errorLog() {
+            DateRangeResult result = DateRangeUtil.defaultRange(ScreenDateType.ERROR_LOG, TODAY);
+            assertThat(result.startDate()).isEqualTo(LocalDate.of(2025, 3, 8));
+            assertThat(result.endDate()).isEqualTo(TODAY);
+        }
+
+        @Test
+        @DisplayName("SYSTEM_MONITOR — 당일")
+        void systemMonitor() {
+            DateRangeResult result = DateRangeUtil.defaultRange(ScreenDateType.SYSTEM_MONITOR, TODAY);
+            assertThat(result.startDate()).isEqualTo(TODAY);
+            assertThat(result.endDate()).isEqualTo(TODAY);
+        }
+    }
+
+    @Nested
+    @DisplayName("isValidRange")
+    class IsValidRange {
+
+        @Test
+        @DisplayName("시작일이 종료일 이전이면 유효")
+        void validRange() {
+            assertThat(DateRangeUtil.isValidRange(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 31)))
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("시작일과 종료일이 동일하면 유효")
+        void sameDate() {
+            assertThat(DateRangeUtil.isValidRange(TODAY, TODAY)).isTrue();
+        }
+
+        @Test
+        @DisplayName("시작일이 종료일 이후이면 무효")
+        void reversedRange() {
+            assertThat(DateRangeUtil.isValidRange(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 1, 1)))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("시작일이 null이면 무효")
+        void nullStart() {
+            assertThat(DateRangeUtil.isValidRange(null, TODAY)).isFalse();
+        }
+
+        @Test
+        @DisplayName("종료일이 null이면 무효")
+        void nullEnd() {
+            assertThat(DateRangeUtil.isValidRange(TODAY, null)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("formatDate / formatDateTime")
+    class Formatting {
+
+        @Test
+        @DisplayName("날짜를 yyyy-MM-dd 형식으로 포맷")
+        void formatDate() {
+            assertThat(DateRangeUtil.formatDate(LocalDate.of(2025, 3, 15))).isEqualTo("2025-03-15");
+        }
+
+        @Test
+        @DisplayName("날짜시간을 yyyy-MM-dd HH:mm:ss 형식으로 포맷")
+        void formatDateTime() {
+            LocalDateTime dt = LocalDateTime.of(2025, 3, 15, 14, 30, 45);
+            assertThat(DateRangeUtil.formatDateTime(dt)).isEqualTo("2025-03-15 14:30:45");
+        }
+    }
+
+    @Nested
+    @DisplayName("parseDate / parseDateTime")
+    class Parsing {
+
+        @Test
+        @DisplayName("yyyy-MM-dd 문자열을 LocalDate로 파싱")
+        void parseDate() {
+            assertThat(DateRangeUtil.parseDate("2025-03-15")).isEqualTo(LocalDate.of(2025, 3, 15));
+        }
+
+        @Test
+        @DisplayName("yyyy-MM-dd HH:mm:ss 문자열을 LocalDateTime으로 파싱")
+        void parseDateTime() {
+            assertThat(DateRangeUtil.parseDateTime("2025-03-15 14:30:45"))
+                    .isEqualTo(LocalDateTime.of(2025, 3, 15, 14, 30, 45));
+        }
+    }
+}

--- a/src/test/java/org/example/springadminv2/util/ExcelExportUtilTest.java
+++ b/src/test/java/org/example/springadminv2/util/ExcelExportUtilTest.java
@@ -1,0 +1,131 @@
+package org.example.springadminv2.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.example.springadminv2.global.dto.ExcelColumnDefinition;
+import org.example.springadminv2.global.util.ExcelExportUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExcelExportUtilTest {
+
+    @Nested
+    @DisplayName("generateFileName")
+    class GenerateFileName {
+
+        @Test
+        @DisplayName("화면명과 날짜로 파일명 생성")
+        void generatesCorrectFileName() {
+            String result = ExcelExportUtil.generateFileName("거래내역", LocalDate.of(2025, 3, 15));
+            assertThat(result).isEqualTo("거래내역_20250315.xlsx");
+        }
+    }
+
+    @Nested
+    @DisplayName("isWithinLimit")
+    class IsWithinLimit {
+
+        @Test
+        @DisplayName("MAX_ROW_LIMIT 이하이면 true")
+        void withinLimit() {
+            assertThat(ExcelExportUtil.isWithinLimit(10_000)).isTrue();
+            assertThat(ExcelExportUtil.isWithinLimit(0)).isTrue();
+        }
+
+        @Test
+        @DisplayName("MAX_ROW_LIMIT 초과이면 false")
+        void exceedsLimit() {
+            assertThat(ExcelExportUtil.isWithinLimit(10_001)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("MAX_ROW_LIMIT 상수")
+    class MaxRowLimit {
+
+        @Test
+        @DisplayName("MAX_ROW_LIMIT은 10000")
+        void maxRowLimitIs10000() {
+            assertThat(ExcelExportUtil.MAX_ROW_LIMIT).isEqualTo(10_000);
+        }
+    }
+
+    @Nested
+    @DisplayName("createWorkbook")
+    class CreateWorkbook {
+
+        private final List<ExcelColumnDefinition> columns =
+                List.of(new ExcelColumnDefinition("이름", "name", 20), new ExcelColumnDefinition("나이", "age", 10));
+
+        @Test
+        @DisplayName("헤더와 데이터가 올바르게 생성됨")
+        void createsHeaderAndData() throws IOException {
+            List<Map<String, Object>> data =
+                    List.of(Map.of("name", "홍길동", "age", 30), Map.of("name", "김철수", "age", 25));
+
+            byte[] bytes = ExcelExportUtil.createWorkbook("테스트", columns, data);
+
+            try (Workbook wb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+                Sheet sheet = wb.getSheet("테스트");
+                assertThat(sheet).isNotNull();
+
+                // 헤더
+                Row header = sheet.getRow(0);
+                assertThat(header.getCell(0).getStringCellValue()).isEqualTo("이름");
+                assertThat(header.getCell(1).getStringCellValue()).isEqualTo("나이");
+
+                // 데이터
+                assertThat(sheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("홍길동");
+                assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("30");
+                assertThat(sheet.getRow(2).getCell(0).getStringCellValue()).isEqualTo("김철수");
+            }
+        }
+
+        @Test
+        @DisplayName("빈 데이터 리스트면 헤더만 생성됨")
+        void emptyDataCreatesHeaderOnly() throws IOException {
+            byte[] bytes = ExcelExportUtil.createWorkbook("빈시트", columns, Collections.emptyList());
+
+            try (Workbook wb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+                Sheet sheet = wb.getSheet("빈시트");
+                assertThat(sheet.getRow(0)).isNotNull();
+                assertThat(sheet.getRow(1)).isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("null 값은 빈 문자열로 처리됨")
+        void nullValueHandledAsEmpty() throws IOException {
+            List<Map<String, Object>> data = List.of(Map.of("name", "테스트"));
+
+            byte[] bytes = ExcelExportUtil.createWorkbook("null테스트", columns, data);
+
+            try (Workbook wb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+                Sheet sheet = wb.getSheet("null테스트");
+                assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("유효한 XLSX 바이트 배열 반환")
+        void returnsValidXlsxBytes() throws IOException {
+            byte[] bytes = ExcelExportUtil.createWorkbook("시트", columns, Collections.emptyList());
+            assertThat(bytes).isNotEmpty();
+            // XLSX 매직 넘버 (PK zip header)
+            assertThat(bytes[0]).isEqualTo((byte) 0x50);
+            assertThat(bytes[1]).isEqualTo((byte) 0x4B);
+        }
+    }
+}

--- a/src/test/java/org/example/springadminv2/util/ScreenDateTypeTest.java
+++ b/src/test/java/org/example/springadminv2/util/ScreenDateTypeTest.java
@@ -1,0 +1,60 @@
+package org.example.springadminv2.util;
+
+import org.example.springadminv2.global.util.ScreenDateType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScreenDateTypeTest {
+
+    @Test
+    @DisplayName("모든 enum 값이 존재하고 getDaysBack이 0 이상")
+    void allValuesHaveNonNegativeDaysBack() {
+        for (ScreenDateType type : ScreenDateType.values()) {
+            assertThat(type.getDaysBack()).isGreaterThanOrEqualTo(0);
+        }
+    }
+
+    @Test
+    @DisplayName("enum 값 개수 검증")
+    void enumValueCount() {
+        assertThat(ScreenDateType.values()).hasSize(5);
+    }
+
+    @Test
+    @DisplayName("HISTORY_AUDIT는 30일")
+    void historyAudit() {
+        assertThat(ScreenDateType.HISTORY_AUDIT.getDaysBack()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("BATCH_EXECUTION은 당일(0일)")
+    void batchExecution() {
+        assertThat(ScreenDateType.BATCH_EXECUTION.getDaysBack()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("TRANSACTION_TRACE는 1일")
+    void transactionTrace() {
+        assertThat(ScreenDateType.TRANSACTION_TRACE.getDaysBack()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("ERROR_LOG는 7일")
+    void errorLog() {
+        assertThat(ScreenDateType.ERROR_LOG.getDaysBack()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("SYSTEM_MONITOR는 당일(0일)")
+    void systemMonitor() {
+        assertThat(ScreenDateType.SYSTEM_MONITOR.getDaysBack()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("valueOf로 enum 값 조회 가능")
+    void valueOfWorks() {
+        assertThat(ScreenDateType.valueOf("HISTORY_AUDIT")).isEqualTo(ScreenDateType.HISTORY_AUDIT);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:menu-resource-permissions.yml
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
     driver-class-name: org.h2.Driver

--- a/src/test/resources/db/h2/dml/security.sql
+++ b/src/test/resources/db/h2/dml/security.sql
@@ -24,23 +24,23 @@ INSERT INTO FWK_USER (USER_ID, USER_NAME, PASSWORD, ROLE_ID, USER_STATE_CODE, LO
 VALUES ('disabled', 'Disabled User', 'password', 'USER', '0', 0,
         '20240101000000', 'system', '$2a$10$dummyhashfortest');
 
--- Test menus
+-- Test menus (real YAML menu IDs)
 INSERT INTO FWK_MENU (MENU_ID, PRIOR_MENU_ID, SORT_ORDER, MENU_NAME, MENU_URL,
                       DISPLAY_YN, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
-VALUES ('MENU001', 'ROOT', 1, 'User Management', '/user', 'Y', 'Y', '20240101000000', 'system');
+VALUES ('v3_menu_manage', 'ROOT', 1, 'Menu Management', '/menu', 'Y', 'Y', '20240101000000', 'system');
 INSERT INTO FWK_MENU (MENU_ID, PRIOR_MENU_ID, SORT_ORDER, MENU_NAME, MENU_URL,
                       DISPLAY_YN, USE_YN, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID)
-VALUES ('MENU002', 'ROOT', 2, 'Role Management', '/role', 'Y', 'Y', '20240101000000', 'system');
+VALUES ('v3_role_manage', 'ROOT', 2, 'Role Management', '/role', 'Y', 'Y', '20240101000000', 'system');
 
--- User-Menu permissions (admin: WRITE on both, user01: READ on MENU001 only)
+-- User-Menu permissions (admin: WRITE on both, user01: READ on v3_menu_manage only)
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID, FAVOR_MENU_ORDER)
-VALUES ('admin', 'MENU001', 'W', '20240101000000', 'system', 0);
+VALUES ('admin', 'v3_menu_manage', 'W', '20240101000000', 'system', 0);
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID, FAVOR_MENU_ORDER)
-VALUES ('admin', 'MENU002', 'W', '20240101000000', 'system', 0);
+VALUES ('admin', 'v3_role_manage', 'W', '20240101000000', 'system', 0);
 INSERT INTO FWK_USER_MENU (USER_ID, MENU_ID, AUTH_CODE, LAST_UPDATE_DTIME, LAST_UPDATE_USER_ID, FAVOR_MENU_ORDER)
-VALUES ('user01', 'MENU001', 'R', '20240101000000', 'system', 0);
+VALUES ('user01', 'v3_menu_manage', 'R', '20240101000000', 'system', 0);
 
--- Role-Menu permissions (ADMIN role: WRITE on both, USER role: READ on MENU001)
-INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'MENU001', 'W');
-INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'MENU002', 'W');
-INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('USER', 'MENU001', 'R');
+-- Role-Menu permissions (ADMIN role: WRITE on both, USER role: READ on v3_menu_manage)
+INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'v3_menu_manage', 'W');
+INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('ADMIN', 'v3_role_manage', 'W');
+INSERT INTO FWK_ROLE_MENU (ROLE_ID, MENU_ID, AUTH_CODE) VALUES ('USER', 'v3_menu_manage', 'R');


### PR DESCRIPTION
## Summary
- YAML 구조를 flat → nested map으로 전환하고 `RES_` prefix를 제거하여 리소스 기반 단일 권한 체계로 통합
- `MenuResourcePermissions`를 `@Component`+SnakeYAML에서 `@ConfigurationProperties`로 전환
- `AuthorityConverter`에서 메뉴 ID 기반 authority 생성을 제거하고 리소스 기반 authority만 유지
- `@PreAuthorize`의 `hasAnyAuthority`(메뉴/리소스 OR) → `hasAuthority`(리소스 단일)로 변경
- 유틸리티(DateRange, Excel, ScreenDateType), CSS/JS 공통 모듈 일괄 추가

## Test plan
- [x] `mvn verify -Dtest.excludedGroups=docker` — 115 tests passed, JaCoCo coverage met
- [x] Spotless check 통과
- [ ] 권한 흐름 확인: DB menu permission → AuthorityConverter → 리소스 기반 authority만 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)